### PR TITLE
FEI-4978: Update codemod to improve handling of express types

### DIFF
--- a/src/convert/migrate/import-specifier.ts
+++ b/src/convert/migrate/import-specifier.ts
@@ -35,8 +35,8 @@ export function maybeMigrateImportSpecifier(
       specifier.local.name = node.local.name;
     }
 
-    // NOTE: `importKind` is always `null` on `ImportSpecifier` nodes
-    // TODO: update the parser to try to fix this
+    // NOTE: `importKind` is always `null` on `ImportSpecifier` nodes so
+    // this doesn't actually work.
     // Handles things like `import {type $Request} from "express";`.
     specifier.importKind = node.importKind;
 

--- a/src/convert/migrate/import-specifier.ts
+++ b/src/convert/migrate/import-specifier.ts
@@ -1,0 +1,45 @@
+import * as t from "@babel/types";
+import MigrationReporter from "../../runner/migration-reporter";
+import { replaceWith } from "../utils/common";
+import { State } from "../../runner/state";
+import { ExpressTypes } from "../utils/type-mappings";
+
+import type { NodePath } from "@babel/traverse";
+
+export function maybeMigrateImportSpecifier(
+  reporter: MigrationReporter,
+  state: State,
+  path: NodePath<t.ImportSpecifier>
+): void {
+  const { node } = path;
+  const parentNode = path.parentPath.node;
+
+  // @ts-expect-error: we know that the parent node has an importKind field on it
+  const importKind = node.importKind || parentNode.importKind;
+
+  if (
+    importKind === "type" &&
+    t.isIdentifier(node.imported) &&
+    Object.keys(ExpressTypes).includes(node.imported.name)
+  ) {
+    // @ts-expect-error: TypeScript's doesn't refined based on `.includes()` calls
+    const replacement = ExpressTypes[node.imported.name];
+
+    const specifier = t.importSpecifier(
+      t.identifier(replacement),
+      t.identifier(replacement)
+    );
+
+    // Handles things like `import type {$Request as Req} from "express";`.
+    if (node.local.name !== node.imported.name) {
+      specifier.local.name = node.local.name;
+    }
+
+    // NOTE: `importKind` is always `null` on `ImportSpecifier` nodes
+    // TODO: update the parser to try to fix this
+    // Handles things like `import {type $Request} from "express";`.
+    specifier.importKind = node.importKind;
+
+    replaceWith(path, specifier, state.config.filePath, reporter);
+  }
+}

--- a/src/convert/migrate/type.ts
+++ b/src/convert/migrate/type.ts
@@ -16,6 +16,8 @@ import {
   ReactTypes,
   SyntheticEvents,
   MomentTypes,
+  ExpressTypes,
+  CustomUtilityTypes,
 } from "../utils/type-mappings";
 import { State } from "../../runner/state";
 import { matchesFullyQualifiedName } from "../utils/matchers";
@@ -731,6 +733,25 @@ function actuallyMigrateType(
           t.tsQualifiedName(
             t.identifier("moment"),
             t.identifier(MomentTypes[id.right.name as keyof typeof MomentTypes])
+          ),
+          params
+        );
+      }
+
+      // TODO: update imports of these as well.
+      // `$Request` → `Request`, `$Response` → `Response`, `$Application` → `Application`
+      if (id.type === "Identifier" && id.name in ExpressTypes) {
+        return t.tsTypeReference(
+          t.identifier(ExpressTypes[id.name as keyof typeof ExpressTypes]),
+          params
+        );
+      }
+
+      // `$Partial` → `Partial`
+      if (id.type === "Identifier" && id.name in CustomUtilityTypes) {
+        return t.tsTypeReference(
+          t.identifier(
+            CustomUtilityTypes[id.name as keyof typeof CustomUtilityTypes]
           ),
           params
         );

--- a/src/convert/migrate/type.ts
+++ b/src/convert/migrate/type.ts
@@ -738,7 +738,6 @@ function actuallyMigrateType(
         );
       }
 
-      // TODO: update imports of these as well.
       // `$Request` → `Request`, `$Response` → `Response`, `$Application` → `Application`
       if (id.type === "Identifier" && id.name in ExpressTypes) {
         return t.tsTypeReference(

--- a/src/convert/type-annotations.test.ts
+++ b/src/convert/type-annotations.test.ts
@@ -863,4 +863,52 @@ class C {
     expect(await transform(src)).toBe(expected);
     expectMigrationReporterMethodCalled("unhandledFlowInputNode");
   });
+
+  describe("express types", () => {
+    it("convert import types", async () => {
+      const src = `import type {$Request, $Response, $Application} from "express";`;
+      const expected = `import type {Request, Response, Application} from "express";`;
+      expect(await transform(src)).toBe(expected);
+    });
+
+    it("handles renames in type imports", async () => {
+      const src = `import type {$Request as Req} from "express";`;
+      const expected = `import type {Request as Req} from "express";`;
+      expect(await transform(src)).toBe(expected);
+    });
+
+    // NOTE: `importKind` is always `null` on `ImportSpecifier` nodes
+    // TODO: update the parser to try to fix this
+    it.skip("handles a mixed imports", async () => {
+      const src = `import {type $Request, app} from "express";`;
+      const expected = `import {type Request, app} from "express";`;
+      expect(await transform(src)).toBe(expected);
+    });
+
+    it("converts $Request to Request", async () => {
+      const src = `let req: $Request;`;
+      const expected = `let req: Request;`;
+      expect(await transform(src)).toBe(expected);
+    });
+
+    it("converts $Response to Response", async () => {
+      const src = `let res: $Response;`;
+      const expected = `let res: Response;`;
+      expect(await transform(src)).toBe(expected);
+    });
+
+    it("converts $Application<Req, Res> to Application<Req, Res>", async () => {
+      const src = `let app: $Application<Req, Res>;`;
+      const expected = `let app: Application<Req, Res>;`;
+      expect(await transform(src)).toBe(expected);
+    });
+  });
+
+  describe("custom utility types", () => {
+    it("converts $Partial<T> to Partial<T>", async () => {
+      const src = `type PartialFoo = $Partial<Foo>;`;
+      const expected = `type PartialFoo = Partial<Foo>;`;
+      expect(await transform(src)).toBe(expected);
+    });
+  });
 });

--- a/src/convert/type-annotations.test.ts
+++ b/src/convert/type-annotations.test.ts
@@ -877,8 +877,8 @@ class C {
       expect(await transform(src)).toBe(expected);
     });
 
-    // NOTE: `importKind` is always `null` on `ImportSpecifier` nodes
-    // TODO: update the parser to try to fix this
+    // NOTE: `importKind` is always `null` on `ImportSpecifier` nodes so
+    // this doesn't actually work.
     it.skip("handles a mixed imports", async () => {
       const src = `import {type $Request, app} from "express";`;
       const expected = `import {type Request, app} from "express";`;

--- a/src/convert/type-annotations.ts
+++ b/src/convert/type-annotations.ts
@@ -3,6 +3,7 @@ import traverse from "@babel/traverse";
 import { replaceWith, inheritLocAndComments } from "./utils/common";
 import { migrateType } from "./migrate/type";
 import { migrateTypeParameterDeclaration } from "./migrate/type-parameter";
+import { maybeMigrateImportSpecifier } from "./migrate/import-specifier";
 import { TransformerInput } from "./transformer";
 import { MetaData } from "./migrate/metadata";
 
@@ -77,6 +78,10 @@ export function transformTypeAnnotations({
         state.config.filePath,
         reporter
       );
+    },
+
+    ImportSpecifier(path) {
+      maybeMigrateImportSpecifier(reporter, state, path);
     },
   });
 }

--- a/src/convert/utils/type-mappings.ts
+++ b/src/convert/utils/type-mappings.ts
@@ -30,3 +30,13 @@ export const SyntheticEvents = {
 export const MomentTypes = {
   MomentDuration: "Duration",
 } as const;
+
+export const ExpressTypes = {
+  $Request: "Request",
+  $Response: "Response",
+  $Application: "Application",
+} as const;
+
+export const CustomUtilityTypes = {
+  $Partial: "Partial",
+} as const;


### PR DESCRIPTION
## Summary:
The Flow lib defs we've been using for express have the types prefixed with a dollar sign.  The official expression types don't use a dollar sign.  This PR adds logic to convert these types both when being used as type annotations as well as when being imported.  It also converts our dollar-prefix 'Partial' type to TS' 'Partial' type.

Issue: FEI-4978

## Test plan:
- yarn test