### PR TITLE
Convert functional components to use React.FC<Props>

### DIFF
--- a/src/convert/default-transformer-chain.ts
+++ b/src/convert/default-transformer-chain.ts
@@ -9,6 +9,7 @@ import {
   privateTypeTransformRunner,
   typeAnnotationTransformRunner,
   removeFlowCommentTransformRunner,
+  functionalComponentTransformerRunner,
 } from "./transform-runners";
 import { Transformer } from "./transformer";
 
@@ -26,4 +27,5 @@ export const defaultTransformerChain: readonly Transformer[] = [
   jsxSpreadTransformRunner,
   importTransformRunner,
   removeFlowCommentTransformRunner,
+  functionalComponentTransformerRunner,
 ];

--- a/src/convert/flow/annotate-params.ts
+++ b/src/convert/flow/annotate-params.ts
@@ -82,7 +82,7 @@ export function annotateParamsWithFlowTypeAtPos(
         (async () => {
           // Get the type Flow is inferring for this unannotated function parameter.
           const flowType = await flowTypeAtPos(state, param.loc!, reporter);
-          if (flowType === null) return;
+          if (flowType == null) return;
 
           // If Flow inferred `empty` then that means there were no calls to the
           // function and therefore no “lower type bounds” for the parameter. This

--- a/src/convert/functional-components.test.ts
+++ b/src/convert/functional-components.test.ts
@@ -8,38 +8,45 @@ describe("Converting functional components", () => {
   describe("Arrow functions", () => {
     it("adds React.FC<Props> type annotation, removes Props type annotation", async () => {
       const src = `const Comp = (props: Props) => { return <h1>Hello</h1> };`;
-      const expected = `const Comp: React.FC<Props> = (props) => { return <h1>Hello</h1> };`;
-      expect(await transform(src)).toBe(expected);
+      expect(await transform(src)).toMatchInlineSnapshot(
+        `"const Comp: React.FC<Props> = (props): React.ReactElement => { return <h1>Hello</h1> };"`
+      );
     });
 
     it("works with FooProps", async () => {
       const src = `const Comp = (props: FooProps) => { return <h1>Hello</h1> };`;
-      const expected = `const Comp: React.FC<FooProps> = (props) => { return <h1>Hello</h1> };`;
-      expect(await transform(src)).toBe(expected);
+      expect(await transform(src)).toMatchInlineSnapshot(
+        `"const Comp: React.FC<FooProps> = (props): React.ReactElement => { return <h1>Hello</h1> };"`
+      );
     });
 
     it("works on lambdas", async () => {
       const src = `const Comp = (props: FooProps) => <h1>Hello</h1>;`;
-      const expected = `const Comp: React.FC<FooProps> = (props) => <h1>Hello</h1>;`;
-      expect(await transform(src)).toBe(expected);
+      expect(await transform(src)).toMatchInlineSnapshot(
+        `"const Comp: React.FC<FooProps> = (props): React.ReactElement => <h1>Hello</h1>;"`
+      );
     });
 
     it("works with destructured props", async () => {
       const src = `const Comp = ({foo, bar}: Props) => { return <h1>Hello</h1> };`;
-      const expected = dedent`const Comp: React.FC<Props> = ({
-          foo,
-          bar,
-        }) => { return <h1>Hello</h1> };`;
-      expect(await transform(src)).toBe(expected);
+      expect(await transform(src)).toMatchInlineSnapshot(`
+        "const Comp: React.FC<Props> = (
+          {
+            foo,
+            bar,
+          },
+        ): React.ReactElement => { return <h1>Hello</h1> };"
+      `);
     });
 
     it("works on functions with inline props type and React.Node return type", async () => {
       const src = `const Comp = (props: {|foo: string, bar: string|}): React.Node => { return <h1>Hello</h1> };`;
-      const expected = dedent`const Comp: React.FC<{
+      expect(await transform(src)).toMatchInlineSnapshot(`
+        "const Comp: React.FC<{
           foo: string,
           bar: string
-        }> = props => { return <h1>Hello</h1> };`;
-      expect(await transform(src)).toBe(expected);
+        }> = (props): React.ReactElement => { return <h1>Hello</h1> };"
+      `);
     });
 
     it("works with components defined within another function", async () => {
@@ -47,43 +54,50 @@ describe("Converting functional components", () => {
         const InnnerComp = (props: InnerProps) => <h1>Hello</h1>;
         return <InnerComp />;
       }`;
-      const expected = dedent`const OuterComp: React.FC<OuterProps> = props => {
-        const InnnerComp: React.FC<InnerProps> = (props) => <h1>Hello</h1>;
-        return <InnerComp />;
-      }`;
-      expect(await transform(src)).toBe(expected);
+      expect(await transform(src)).toMatchInlineSnapshot(`
+        "const OuterComp: React.FC<OuterProps> = (props): React.ReactElement => {
+          const InnnerComp: React.FC<InnerProps> = (props): React.ReactElement => <h1>Hello</h1>;
+          return <InnerComp />;
+        }"
+      `);
     });
   });
 
   describe("Anonymous function expressions", () => {
     it("adds React.FC<Props> type annotation, removes Props type annotation", async () => {
       const src = `const Comp = function (props: Props) { return <h1>Hello</h1> };`;
-      const expected = `const Comp: React.FC<Props> = function (props) { return <h1>Hello</h1> };`;
-      expect(await transform(src)).toBe(expected);
+      expect(await transform(src)).toMatchInlineSnapshot(
+        `"const Comp: React.FC<Props> = function(props): React.ReactElement { return <h1>Hello</h1> };"`
+      );
     });
 
     it("works with FooProps", async () => {
       const src = `const Comp = function (props: FooProps) { return <h1>Hello</h1> };`;
-      const expected = `const Comp: React.FC<FooProps> = function (props) { return <h1>Hello</h1> };`;
-      expect(await transform(src)).toBe(expected);
+      expect(await transform(src)).toMatchInlineSnapshot(
+        `"const Comp: React.FC<FooProps> = function(props): React.ReactElement { return <h1>Hello</h1> };"`
+      );
     });
 
     it("works with destructured props", async () => {
       const src = `const Comp = function ({foo, bar}: Props) { return <h1>Hello</h1> };`;
-      const expected = dedent`const Comp: React.FC<Props> = function ({
-          foo,
-          bar,
-        }) { return <h1>Hello</h1> };`;
-      expect(await transform(src)).toBe(expected);
+      expect(await transform(src)).toMatchInlineSnapshot(`
+        "const Comp: React.FC<Props> = function(
+          {
+            foo,
+            bar,
+          },
+        ): React.ReactElement { return <h1>Hello</h1> };"
+      `);
     });
 
     it("works on functions with inline props type and React.Node return type", async () => {
       const src = `const Comp = function (props: {|foo: string, bar: string|}): React.Node { return <h1>Hello</h1> };`;
-      const expected = dedent`const Comp: React.FC<{
+      expect(await transform(src)).toMatchInlineSnapshot(`
+        "const Comp: React.FC<{
           foo: string,
           bar: string
-        }> = function(props) { return <h1>Hello</h1> };`;
-      expect(await transform(src)).toBe(expected);
+        }> = function(props): React.ReactElement { return <h1>Hello</h1> };"
+      `);
     });
 
     it("works with components defined within another function", async () => {
@@ -91,45 +105,50 @@ describe("Converting functional components", () => {
         const InnnerComp = function (props: InnerProps) { return <h1>Hello</h1>; };
         return <InnerComp />;
       }`;
-      const expected = dedent`const OuterComp: React.FC<OuterProps> = function(props) {
-        const InnnerComp: React.FC<InnerProps> = function (props) { return <h1>Hello</h1>; };
-        return <InnerComp />;
-      }`;
-      expect(await transform(src)).toBe(expected);
+      expect(await transform(src)).toMatchInlineSnapshot(`
+        "const OuterComp: React.FC<OuterProps> = function(props): React.ReactElement {
+          const InnnerComp: React.FC<InnerProps> = function(props): React.ReactElement { return <h1>Hello</h1>; };
+          return <InnerComp />;
+        }"
+      `);
     });
   });
 
   describe("Function declarations", () => {
     it("converts it to an function expression", async () => {
       const src = `function Comp(props: Props) { return <h1>Hello</h1> };`;
-      const expected = `const Comp: React.FC<Props> = function(props) { return <h1>Hello</h1> };`;
-      expect(await transform(src)).toBe(expected);
+      expect(await transform(src)).toMatchInlineSnapshot(
+        `"const Comp: React.FC<Props> = function(props): React.ReactElement { return <h1>Hello</h1> };"`
+      );
     });
 
     it("works with FooProps", async () => {
       const src = `function Comp(props: FooProps) { return <h1>Hello</h1> };`;
-      const expected = `const Comp: React.FC<FooProps> = function(props) { return <h1>Hello</h1> };`;
-      expect(await transform(src)).toBe(expected);
+      expect(await transform(src)).toMatchInlineSnapshot(
+        `"const Comp: React.FC<FooProps> = function(props): React.ReactElement { return <h1>Hello</h1> };"`
+      );
     });
 
     it("works with destructured props", async () => {
       const src = `function Comp({foo, bar}: Props) { return <h1>Hello</h1> };`;
-      const expected = dedent`const Comp: React.FC<Props> = function(
-        {
-          foo,
-          bar,
-        },
-      ) { return <h1>Hello</h1> };`;
-      expect(await transform(src)).toBe(expected);
+      expect(await transform(src)).toMatchInlineSnapshot(`
+        "const Comp: React.FC<Props> = function(
+          {
+            foo,
+            bar,
+          },
+        ): React.ReactElement { return <h1>Hello</h1> };"
+      `);
     });
 
     it("works on functions with inline props type and React.Node return type", async () => {
       const src = `function Comp(props: {|foo: string, bar: string|}): React.Node { return <h1>Hello</h1> };`;
-      const expected = dedent`const Comp: React.FC<{
+      expect(await transform(src)).toMatchInlineSnapshot(`
+        "const Comp: React.FC<{
           foo: string,
           bar: string
-        }> = function(props) { return <h1>Hello</h1> };`;
-      expect(await transform(src)).toBe(expected);
+        }> = function(props): React.ReactElement { return <h1>Hello</h1> };"
+      `);
     });
 
     it("works with components defined within another function", async () => {
@@ -137,48 +156,53 @@ describe("Converting functional components", () => {
         function InnnerComp(props: InnerProps) { return <h1>Hello</h1>; };
         return <InnerComp />;
       }`;
-      const expected = dedent`const OuterComp: React.FC<OuterProps> = function(props) {
-        const InnnerComp: React.FC<InnerProps> = function(props) { return <h1>Hello</h1>; };
-        return <InnerComp />;
-      };`;
-      expect(await transform(src)).toBe(expected);
+      expect(await transform(src)).toMatchInlineSnapshot(`
+        "const OuterComp: React.FC<OuterProps> = function(props): React.ReactElement {
+          const InnnerComp: React.FC<InnerProps> = function(props): React.ReactElement { return <h1>Hello</h1>; };
+          return <InnerComp />;
+        };"
+      `);
     });
   });
 
   describe("Exporting function", () => {
     it("handles named exports", async () => {
       const src = `export function Comp(props: Props) { return <h1>Hello</h1> };`;
-      const expected = `export const Comp: React.FC<Props> = function(props) { return <h1>Hello</h1> };;`;
-      expect(await transform(src)).toBe(expected);
+      expect(await transform(src)).toMatchInlineSnapshot(
+        `"export const Comp: React.FC<Props> = function(props): React.ReactElement { return <h1>Hello</h1> };;"`
+      );
     });
 
     it("handles default exports with props param", async () => {
       const src = `export default function Comp(props: Props) { return <h1>Hello</h1> };`;
-      const expected = dedent`const Comp: React.FC<Props> = function(props) { return <h1>Hello</h1> };
-      export default Comp;`;
-      expect(await transform(src)).toBe(expected);
+      expect(await transform(src)).toMatchInlineSnapshot(`
+        "const Comp: React.FC<Props> = function(props): React.ReactElement { return <h1>Hello</h1> };
+        export default Comp;"
+      `);
     });
 
     it("handles default exports with inline props", async () => {
       const src = `export default function Comp(props: {|foo: string, bar: string|}): React.Node { return <h1>Hello</h1> };`;
-      const expected = dedent`const Comp: React.FC<{
-        foo: string,
-        bar: string
-      }> = function(props) { return <h1>Hello</h1> };
-      export default Comp;`;
-      expect(await transform(src)).toBe(expected);
+      expect(await transform(src)).toMatchInlineSnapshot(`
+        "const Comp: React.FC<{
+          foo: string,
+          bar: string
+        }> = function(props): React.ReactElement { return <h1>Hello</h1> };
+        export default Comp;"
+      `);
     });
 
     it("handles default exports with destructured props", async () => {
       const src = `export default function Comp({foo, bar}: Props): React.Node { return <h1>Hello</h1> };`;
-      const expected = dedent`const Comp: React.FC<Props> = function(
-        {
-          foo,
-          bar,
-        },
-      ) { return <h1>Hello</h1> };
-      export default Comp;`;
-      expect(await transform(src)).toBe(expected);
+      expect(await transform(src)).toMatchInlineSnapshot(`
+        "const Comp: React.FC<Props> = function(
+          {
+            foo,
+            bar,
+          },
+        ): React.ReactElement { return <h1>Hello</h1> };
+        export default Comp;"
+      `);
     });
   });
 });

--- a/src/convert/functional-components.test.ts
+++ b/src/convert/functional-components.test.ts
@@ -1,0 +1,147 @@
+import dedent from "dedent";
+import { transform } from "./utils/testing";
+
+jest.mock("../runner/migration-reporter/migration-reporter.ts");
+jest.mock("./flow/type-at-pos.ts");
+
+describe("Converting functional components", () => {
+  describe("Arrow functions", () => {
+    it("adds React.FC<Props> type annotation, removes Props type annotation", async () => {
+      const src = `const Comp = (props: Props) => { return <h1>Hello</h1> };`;
+      const expected = `const Comp: React.FC<Props> = (props) => { return <h1>Hello</h1> };`;
+      expect(await transform(src)).toBe(expected);
+    });
+
+    it("works with FooProps", async () => {
+      const src = `const Comp = (props: FooProps) => { return <h1>Hello</h1> };`;
+      const expected = `const Comp: React.FC<FooProps> = (props) => { return <h1>Hello</h1> };`;
+      expect(await transform(src)).toBe(expected);
+    });
+
+    it("works on lambdas", async () => {
+      const src = `const Comp = (props: FooProps) => <h1>Hello</h1>;`;
+      const expected = `const Comp: React.FC<FooProps> = (props) => <h1>Hello</h1>;`;
+      expect(await transform(src)).toBe(expected);
+    });
+
+    it("works with destructured props", async () => {
+      const src = `const Comp = ({foo, bar}: Props) => { return <h1>Hello</h1> };`;
+      const expected = dedent`const Comp: React.FC<Props> = ({
+          foo,
+          bar,
+        }) => { return <h1>Hello</h1> };`;
+      expect(await transform(src)).toBe(expected);
+    });
+
+    it("works on functions with inline props type and React.Node return type", async () => {
+      const src = `const Comp = (props: {|foo: string, bar: string|}): React.Node => { return <h1>Hello</h1> };`;
+      const expected = dedent`const Comp: React.FC<{
+          foo: string,
+          bar: string
+        }> = props => { return <h1>Hello</h1> };`;
+      expect(await transform(src)).toBe(expected);
+    });
+
+    it("works with components defined within another function", async () => {
+      const src = dedent`const OuterComp = (props: OuterProps): React.Node => {
+        const InnnerComp = (props: InnerProps) => <h1>Hello</h1>;
+        return <InnerComp />;
+      }`;
+      const expected = dedent`const OuterComp: React.FC<OuterProps> = props => {
+        const InnnerComp: React.FC<InnerProps> = (props) => <h1>Hello</h1>;
+        return <InnerComp />;
+      }`;
+      expect(await transform(src)).toBe(expected);
+    });
+  });
+
+  describe("Anonymous function expressions", () => {
+    it("adds React.FC<Props> type annotation, removes Props type annotation", async () => {
+      const src = `const Comp = function (props: Props) { return <h1>Hello</h1> };`;
+      const expected = `const Comp: React.FC<Props> = function (props) { return <h1>Hello</h1> };`;
+      expect(await transform(src)).toBe(expected);
+    });
+
+    it("works with FooProps", async () => {
+      const src = `const Comp = function (props: FooProps) { return <h1>Hello</h1> };`;
+      const expected = `const Comp: React.FC<FooProps> = function (props) { return <h1>Hello</h1> };`;
+      expect(await transform(src)).toBe(expected);
+    });
+
+    it("works with destructured props", async () => {
+      const src = `const Comp = function ({foo, bar}: Props) { return <h1>Hello</h1> };`;
+      const expected = dedent`const Comp: React.FC<Props> = function ({
+          foo,
+          bar,
+        }) { return <h1>Hello</h1> };`;
+      expect(await transform(src)).toBe(expected);
+    });
+
+    it("works on functions with inline props type and React.Node return type", async () => {
+      const src = `const Comp = function (props: {|foo: string, bar: string|}): React.Node { return <h1>Hello</h1> };`;
+      const expected = dedent`const Comp: React.FC<{
+          foo: string,
+          bar: string
+        }> = function(props) { return <h1>Hello</h1> };`;
+      expect(await transform(src)).toBe(expected);
+    });
+
+    it("works with components defined within another function", async () => {
+      const src = dedent`const OuterComp = function (props: OuterProps): React.Node {
+        const InnnerComp = function (props: InnerProps) { return <h1>Hello</h1>; };
+        return <InnerComp />;
+      }`;
+      const expected = dedent`const OuterComp: React.FC<OuterProps> = function(props) {
+        const InnnerComp: React.FC<InnerProps> = function (props) { return <h1>Hello</h1>; };
+        return <InnerComp />;
+      }`;
+      expect(await transform(src)).toBe(expected);
+    });
+  });
+
+  describe("Function declarations", () => {
+    it("converts it to an function expression", async () => {
+      const src = `function Comp(props: Props) { return <h1>Hello</h1> };`;
+      const expected = `const Comp: React.FC<Props> = function(props) { return <h1>Hello</h1> };`;
+      expect(await transform(src)).toBe(expected);
+    });
+
+    it("works with FooProps", async () => {
+      const src = `function Comp(props: FooProps) { return <h1>Hello</h1> };`;
+      const expected = `const Comp: React.FC<FooProps> = function(props) { return <h1>Hello</h1> };`;
+      expect(await transform(src)).toBe(expected);
+    });
+
+    it("works with destructured props", async () => {
+      const src = `function Comp({foo, bar}: Props) { return <h1>Hello</h1> };`;
+      const expected = dedent`const Comp: React.FC<Props> = function(
+        {
+          foo,
+          bar,
+        },
+      ) { return <h1>Hello</h1> };`;
+      expect(await transform(src)).toBe(expected);
+    });
+
+    it("works on functions with inline props type and React.Node return type", async () => {
+      const src = `function Comp(props: {|foo: string, bar: string|}): React.Node { return <h1>Hello</h1> };`;
+      const expected = dedent`const Comp: React.FC<{
+          foo: string,
+          bar: string
+        }> = function(props) { return <h1>Hello</h1> };`;
+      expect(await transform(src)).toBe(expected);
+    });
+
+    it("works with components defined within another function", async () => {
+      const src = dedent`function OuterComp(props: OuterProps): React.Node {
+        function InnnerComp(props: InnerProps) { return <h1>Hello</h1>; };
+        return <InnerComp />;
+      }`;
+      const expected = dedent`const OuterComp: React.FC<OuterProps> = function(props) {
+        const InnnerComp: React.FC<InnerProps> = function(props) { return <h1>Hello</h1>; };
+        return <InnerComp />;
+      };`;
+      expect(await transform(src)).toBe(expected);
+    });
+  });
+});

--- a/src/convert/functional-components.test.ts
+++ b/src/convert/functional-components.test.ts
@@ -144,4 +144,41 @@ describe("Converting functional components", () => {
       expect(await transform(src)).toBe(expected);
     });
   });
+
+  describe("Exporting function", () => {
+    it("handles named exports", async () => {
+      const src = `export function Comp(props: Props) { return <h1>Hello</h1> };`;
+      const expected = `export const Comp: React.FC<Props> = function(props) { return <h1>Hello</h1> };;`;
+      expect(await transform(src)).toBe(expected);
+    });
+
+    it("handles default exports with props param", async () => {
+      const src = `export default function Comp(props: Props) { return <h1>Hello</h1> };`;
+      const expected = dedent`const Comp: React.FC<Props> = function(props) { return <h1>Hello</h1> };
+      export default Comp;`;
+      expect(await transform(src)).toBe(expected);
+    });
+
+    it("handles default exports with inline props", async () => {
+      const src = `export default function Comp(props: {|foo: string, bar: string|}): React.Node { return <h1>Hello</h1> };`;
+      const expected = dedent`const Comp: React.FC<{
+        foo: string,
+        bar: string
+      }> = function(props) { return <h1>Hello</h1> };
+      export default Comp;`;
+      expect(await transform(src)).toBe(expected);
+    });
+
+    it("handles default exports with destructured props", async () => {
+      const src = `export default function Comp({foo, bar}: Props): React.Node { return <h1>Hello</h1> };`;
+      const expected = dedent`const Comp: React.FC<Props> = function(
+        {
+          foo,
+          bar,
+        },
+      ) { return <h1>Hello</h1> };
+      export default Comp;`;
+      expect(await transform(src)).toBe(expected);
+    });
+  });
 });

--- a/src/convert/functional-components.ts
+++ b/src/convert/functional-components.ts
@@ -2,7 +2,7 @@ import * as t from "@babel/types";
 import traverse from "@babel/traverse";
 
 import { TransformerInput } from "./transformer";
-import { replaceWith } from "./utils/common";
+import { replaceWith, replaceWithMultiple } from "./utils/common";
 
 export function transformFunctionalComponents({
   reporter,
@@ -24,13 +24,32 @@ export function transformFunctionalComponents({
             const [param] = params;
 
             if (
-              t.isIdentifier(id) &&
-              t.isTSTypeAnnotation(param.typeAnnotation) &&
-              t.isTSTypeReference(param.typeAnnotation.typeAnnotation) &&
-              t.isIdentifier(param.typeAnnotation.typeAnnotation.typeName) &&
-              param.typeAnnotation.typeAnnotation.typeName.name.endsWith(
-                "Props"
-              )
+              (t.isIdentifier(id) &&
+                t.isTSTypeAnnotation(param.typeAnnotation) &&
+                t.isTSTypeReference(param.typeAnnotation.typeAnnotation) &&
+                t.isIdentifier(param.typeAnnotation.typeAnnotation.typeName) &&
+                param.typeAnnotation.typeAnnotation.typeName.name.endsWith(
+                  "Props"
+                )) ||
+              (t.isIdentifier(id) &&
+                t.isTSTypeAnnotation(param.typeAnnotation) &&
+                t.isTSTypeAnnotation(arrowFn.returnType) &&
+                t.isTSTypeReference(arrowFn.returnType.typeAnnotation) &&
+                t.isTSQualifiedName(
+                  arrowFn.returnType.typeAnnotation.typeName
+                ) &&
+                t.isIdentifier(
+                  arrowFn.returnType.typeAnnotation.typeName.left,
+                  {
+                    name: "React",
+                  }
+                ) &&
+                t.isIdentifier(
+                  arrowFn.returnType.typeAnnotation.typeName.right
+                ) &&
+                ["ReactNode", "ReactElement"].includes(
+                  arrowFn.returnType.typeAnnotation.typeName.right.name
+                ))
             ) {
               // HACK(kevinb): We mutate the nodes directly instead of using `replaceWith`
               // because that function will end up in an infinite loop if we try to pass
@@ -45,62 +64,38 @@ export function transformFunctionalComponents({
               );
               delete param.typeAnnotation;
               delete arrowFn.returnType;
-              return;
-            }
-
-            if (
-              t.isIdentifier(id) &&
-              t.isTSTypeAnnotation(param.typeAnnotation) &&
-              t.isTSTypeAnnotation(arrowFn.returnType) &&
-              t.isTSTypeReference(arrowFn.returnType.typeAnnotation) &&
-              t.isTSQualifiedName(arrowFn.returnType.typeAnnotation.typeName) &&
-              t.isIdentifier(arrowFn.returnType.typeAnnotation.typeName.left, {
-                name: "React",
-              }) &&
-              t.isIdentifier(
-                arrowFn.returnType.typeAnnotation.typeName.right
-              ) &&
-              ["ReactNode", "ReactElement"].includes(
-                arrowFn.returnType.typeAnnotation.typeName.right.name
-              )
-            ) {
-              // HACK(kevinb): We mutate the nodes directly instead of using `replaceWith`
-              // because that function will end up in an infinite loop if we try to pass
-              // it a node that contains any descendent nodes of the original node.
-              id.typeAnnotation = t.tsTypeAnnotation(
-                t.tsTypeReference(
-                  t.tsQualifiedName(t.identifier("React"), t.identifier("FC")),
-                  t.tsTypeParameterInstantiation([
-                    param.typeAnnotation.typeAnnotation,
-                  ])
-                )
-              );
-              delete param.typeAnnotation;
-              delete arrowFn.returnType;
-              return;
             }
           }
         }
       },
     },
-    // TODO: handle
-    // - function Foo(props: Props) {}
-    // - export default function(props: Props) {}
     FunctionDeclaration: {
       exit(path) {
-        if (!t.isExportDefaultSpecifier(path.parent)) {
+        if (!t.isExportDefaultDeclaration(path.parent)) {
           const { id, params, returnType, body } = path.node;
           if (params.length === 1) {
             const [param] = params;
 
             if (
-              t.isIdentifier(id) &&
-              t.isTSTypeAnnotation(param.typeAnnotation) &&
-              t.isTSTypeReference(param.typeAnnotation.typeAnnotation) &&
-              t.isIdentifier(param.typeAnnotation.typeAnnotation.typeName) &&
-              param.typeAnnotation.typeAnnotation.typeName.name.endsWith(
-                "Props"
-              )
+              (t.isIdentifier(id) &&
+                t.isTSTypeAnnotation(param.typeAnnotation) &&
+                t.isTSTypeReference(param.typeAnnotation.typeAnnotation) &&
+                t.isIdentifier(param.typeAnnotation.typeAnnotation.typeName) &&
+                param.typeAnnotation.typeAnnotation.typeName.name.endsWith(
+                  "Props"
+                )) ||
+              (t.isIdentifier(id) &&
+                t.isTSTypeAnnotation(param.typeAnnotation) &&
+                t.isTSTypeAnnotation(returnType) &&
+                t.isTSTypeReference(returnType.typeAnnotation) &&
+                t.isTSQualifiedName(returnType.typeAnnotation.typeName) &&
+                t.isIdentifier(returnType.typeAnnotation.typeName.left, {
+                  name: "React",
+                }) &&
+                t.isIdentifier(returnType.typeAnnotation.typeName.right) &&
+                ["ReactNode", "ReactElement"].includes(
+                  returnType.typeAnnotation.typeName.right.name
+                ))
             ) {
               // HACK(kevinb): We mutate the nodes directly instead of using `replaceWith`
               // because that function will end up in an infinite loop if we try to pass
@@ -128,59 +123,74 @@ export function transformFunctionalComponents({
 
               delete param.typeAnnotation;
               delete path.node.returnType;
-              return;
-            }
-
-            if (
-              t.isIdentifier(id) &&
-              t.isTSTypeAnnotation(param.typeAnnotation) &&
-              t.isTSTypeAnnotation(returnType) &&
-              t.isTSTypeReference(returnType.typeAnnotation) &&
-              t.isTSQualifiedName(returnType.typeAnnotation.typeName) &&
-              t.isIdentifier(returnType.typeAnnotation.typeName.left, {
-                name: "React",
-              }) &&
-              t.isIdentifier(returnType.typeAnnotation.typeName.right) &&
-              ["ReactNode", "ReactElement"].includes(
-                returnType.typeAnnotation.typeName.right.name
-              )
-            ) {
-              // HACK(kevinb): We mutate the nodes directly instead of using `replaceWith`
-              // because that function will end up in an infinite loop if we try to pass
-              // it a node that contains any descendent nodes of the original node.
-              id.typeAnnotation = t.tsTypeAnnotation(
-                t.tsTypeReference(
-                  t.tsQualifiedName(t.identifier("React"), t.identifier("FC")),
-                  t.tsTypeParameterInstantiation([
-                    param.typeAnnotation.typeAnnotation,
-                  ])
-                )
-              );
-
-              replaceWith(
-                path,
-                t.variableDeclaration("const", [
-                  t.variableDeclarator(
-                    id,
-                    t.functionExpression(null, params, body)
-                  ),
-                ]),
-                state.config.filePath,
-                reporter
-              );
-
-              delete param.typeAnnotation;
-              delete path.node.returnType;
-              return;
             }
           }
         }
       },
     },
-    ExportDeclaration: {
+    ExportDefaultDeclaration: {
       exit(path) {
-        // TODO: implement this
-        path.node;
+        const { node } = path;
+        if (t.isFunctionDeclaration(node.declaration)) {
+          const { id, params, returnType, body } = node.declaration;
+          if (params.length === 1) {
+            const [param] = params;
+
+            if (
+              (t.isIdentifier(id) &&
+                t.isTSTypeAnnotation(param.typeAnnotation) &&
+                t.isTSTypeReference(param.typeAnnotation.typeAnnotation) &&
+                t.isIdentifier(param.typeAnnotation.typeAnnotation.typeName) &&
+                param.typeAnnotation.typeAnnotation.typeName.name.endsWith(
+                  "Props"
+                )) ||
+              (t.isIdentifier(id) &&
+                t.isTSTypeAnnotation(param.typeAnnotation) &&
+                t.isTSTypeAnnotation(returnType) &&
+                t.isTSTypeReference(returnType.typeAnnotation) &&
+                t.isTSQualifiedName(returnType.typeAnnotation.typeName) &&
+                t.isIdentifier(returnType.typeAnnotation.typeName.left, {
+                  name: "React",
+                }) &&
+                t.isIdentifier(returnType.typeAnnotation.typeName.right) &&
+                ["ReactNode", "ReactElement"].includes(
+                  returnType.typeAnnotation.typeName.right.name
+                ))
+            ) {
+              // HACK(kevinb): We mutate the nodes directly instead of using `replaceWith`
+              // because that function will end up in an infinite loop if we try to pass
+              // it a node that contains any descendent nodes of the original node.
+              id.typeAnnotation = t.tsTypeAnnotation(
+                t.tsTypeReference(
+                  t.tsQualifiedName(t.identifier("React"), t.identifier("FC")),
+                  t.tsTypeParameterInstantiation([
+                    param.typeAnnotation.typeAnnotation,
+                  ])
+                )
+              );
+
+              const newNodes = [
+                t.variableDeclaration("const", [
+                  t.variableDeclarator(
+                    id,
+                    t.functionExpression(null, params, body)
+                  ),
+                ]),
+                t.exportDefaultDeclaration(t.identifier("Comp")),
+              ];
+
+              replaceWithMultiple(
+                path,
+                newNodes,
+                state.config.filePath,
+                reporter
+              );
+
+              delete param.typeAnnotation;
+              delete node.declaration.returnType;
+            }
+          }
+        }
       },
     },
   });

--- a/src/convert/functional-components.ts
+++ b/src/convert/functional-components.ts
@@ -1,0 +1,189 @@
+import * as t from "@babel/types";
+import traverse from "@babel/traverse";
+
+import { TransformerInput } from "./transformer";
+import { replaceWith } from "./utils/common";
+
+export function transformFunctionalComponents({
+  reporter,
+  state,
+  file,
+}: TransformerInput): Promise<unknown> {
+  const awaitPromises: Array<Promise<unknown>> = [];
+
+  traverse(file, {
+    VariableDeclarator: {
+      exit(path) {
+        if (
+          t.isArrowFunctionExpression(path.node.init) ||
+          t.isFunctionExpression(path.node.init)
+        ) {
+          const { id, init: arrowFn } = path.node;
+          const { params } = arrowFn;
+          if (params.length === 1) {
+            const [param] = params;
+
+            if (
+              t.isIdentifier(id) &&
+              t.isTSTypeAnnotation(param.typeAnnotation) &&
+              t.isTSTypeReference(param.typeAnnotation.typeAnnotation) &&
+              t.isIdentifier(param.typeAnnotation.typeAnnotation.typeName) &&
+              param.typeAnnotation.typeAnnotation.typeName.name.endsWith(
+                "Props"
+              )
+            ) {
+              // HACK(kevinb): We mutate the nodes directly instead of using `replaceWith`
+              // because that function will end up in an infinite loop if we try to pass
+              // it a node that contains any descendent nodes of the original node.
+              id.typeAnnotation = t.tsTypeAnnotation(
+                t.tsTypeReference(
+                  t.tsQualifiedName(t.identifier("React"), t.identifier("FC")),
+                  t.tsTypeParameterInstantiation([
+                    param.typeAnnotation.typeAnnotation,
+                  ])
+                )
+              );
+              delete param.typeAnnotation;
+              delete arrowFn.returnType;
+              return;
+            }
+
+            if (
+              t.isIdentifier(id) &&
+              t.isTSTypeAnnotation(param.typeAnnotation) &&
+              t.isTSTypeAnnotation(arrowFn.returnType) &&
+              t.isTSTypeReference(arrowFn.returnType.typeAnnotation) &&
+              t.isTSQualifiedName(arrowFn.returnType.typeAnnotation.typeName) &&
+              t.isIdentifier(arrowFn.returnType.typeAnnotation.typeName.left, {
+                name: "React",
+              }) &&
+              t.isIdentifier(
+                arrowFn.returnType.typeAnnotation.typeName.right
+              ) &&
+              ["ReactNode", "ReactElement"].includes(
+                arrowFn.returnType.typeAnnotation.typeName.right.name
+              )
+            ) {
+              // HACK(kevinb): We mutate the nodes directly instead of using `replaceWith`
+              // because that function will end up in an infinite loop if we try to pass
+              // it a node that contains any descendent nodes of the original node.
+              id.typeAnnotation = t.tsTypeAnnotation(
+                t.tsTypeReference(
+                  t.tsQualifiedName(t.identifier("React"), t.identifier("FC")),
+                  t.tsTypeParameterInstantiation([
+                    param.typeAnnotation.typeAnnotation,
+                  ])
+                )
+              );
+              delete param.typeAnnotation;
+              delete arrowFn.returnType;
+              return;
+            }
+          }
+        }
+      },
+    },
+    // TODO: handle
+    // - function Foo(props: Props) {}
+    // - export default function(props: Props) {}
+    FunctionDeclaration: {
+      exit(path) {
+        if (!t.isExportDefaultSpecifier(path.parent)) {
+          const { id, params, returnType, body } = path.node;
+          if (params.length === 1) {
+            const [param] = params;
+
+            if (
+              t.isIdentifier(id) &&
+              t.isTSTypeAnnotation(param.typeAnnotation) &&
+              t.isTSTypeReference(param.typeAnnotation.typeAnnotation) &&
+              t.isIdentifier(param.typeAnnotation.typeAnnotation.typeName) &&
+              param.typeAnnotation.typeAnnotation.typeName.name.endsWith(
+                "Props"
+              )
+            ) {
+              // HACK(kevinb): We mutate the nodes directly instead of using `replaceWith`
+              // because that function will end up in an infinite loop if we try to pass
+              // it a node that contains any descendent nodes of the original node.
+              id.typeAnnotation = t.tsTypeAnnotation(
+                t.tsTypeReference(
+                  t.tsQualifiedName(t.identifier("React"), t.identifier("FC")),
+                  t.tsTypeParameterInstantiation([
+                    param.typeAnnotation.typeAnnotation,
+                  ])
+                )
+              );
+
+              replaceWith(
+                path,
+                t.variableDeclaration("const", [
+                  t.variableDeclarator(
+                    id,
+                    t.functionExpression(null, params, body)
+                  ),
+                ]),
+                state.config.filePath,
+                reporter
+              );
+
+              delete param.typeAnnotation;
+              delete path.node.returnType;
+              return;
+            }
+
+            if (
+              t.isIdentifier(id) &&
+              t.isTSTypeAnnotation(param.typeAnnotation) &&
+              t.isTSTypeAnnotation(returnType) &&
+              t.isTSTypeReference(returnType.typeAnnotation) &&
+              t.isTSQualifiedName(returnType.typeAnnotation.typeName) &&
+              t.isIdentifier(returnType.typeAnnotation.typeName.left, {
+                name: "React",
+              }) &&
+              t.isIdentifier(returnType.typeAnnotation.typeName.right) &&
+              ["ReactNode", "ReactElement"].includes(
+                returnType.typeAnnotation.typeName.right.name
+              )
+            ) {
+              // HACK(kevinb): We mutate the nodes directly instead of using `replaceWith`
+              // because that function will end up in an infinite loop if we try to pass
+              // it a node that contains any descendent nodes of the original node.
+              id.typeAnnotation = t.tsTypeAnnotation(
+                t.tsTypeReference(
+                  t.tsQualifiedName(t.identifier("React"), t.identifier("FC")),
+                  t.tsTypeParameterInstantiation([
+                    param.typeAnnotation.typeAnnotation,
+                  ])
+                )
+              );
+
+              replaceWith(
+                path,
+                t.variableDeclaration("const", [
+                  t.variableDeclarator(
+                    id,
+                    t.functionExpression(null, params, body)
+                  ),
+                ]),
+                state.config.filePath,
+                reporter
+              );
+
+              delete param.typeAnnotation;
+              delete path.node.returnType;
+              return;
+            }
+          }
+        }
+      },
+    },
+    ExportDeclaration: {
+      exit(path) {
+        // TODO: implement this
+        path.node;
+      },
+    },
+  });
+
+  return Promise.all(awaitPromises);
+}

--- a/src/convert/jsx-spread/jsx-spread.test.ts
+++ b/src/convert/jsx-spread/jsx-spread.test.ts
@@ -296,7 +296,7 @@ describe("transform spread JSX attributes", () => {
       foo: number
     };
 
-    const Foobar: React.FC<Props> = function(x) { 
+    const Foobar: React.FC<Props> = function(x): React.ReactElement { 
       const { it, ...rest } = x;
       const El = Mine;
       return <El it={it} {...rest} />

--- a/src/convert/jsx-spread/jsx-spread.test.ts
+++ b/src/convert/jsx-spread/jsx-spread.test.ts
@@ -296,11 +296,11 @@ describe("transform spread JSX attributes", () => {
       foo: number
     };
 
-    function Foobar(x: Props) { 
+    const Foobar: React.FC<Props> = function(x) { 
       const { it, ...rest } = x;
       const El = Mine;
       return <El it={it} {...rest} />
-    }`;
+    };`;
 
     expect(
       await transform(

--- a/src/convert/private-types.test.ts
+++ b/src/convert/private-types.test.ts
@@ -17,7 +17,7 @@ describe("transform type annotations", () => {
 
   it("converts React$Element", async () => {
     const src = `const Component = (props: Props): React$Element => {return <div />};`;
-    const expected = `const Component: React.FC<Props> = props => {return <div />};`;
+    const expected = `const Component: React.FC<Props> = (props): React.ReactElement => {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -29,7 +29,7 @@ describe("transform type annotations", () => {
 
   it("converts Flow namespaces", async () => {
     const src = `const Component = (props: Props): Any$Thing => {return <div />};`;
-    const expected = `const Component: React.FC<Props> = props => {return <div />};`;
+    const expected = `const Component: React.FC<Props> = (props): React.ReactElement => {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -40,7 +40,7 @@ describe("transform type annotations", () => {
       },
     });
     const src = `const Component = (props: Props): Any$Thing => {return <div />};`;
-    const expected = `const Component: React.FC<Props> = props => {return <div />};`;
+    const expected = `const Component: React.FC<Props> = (props): React.ReactElement => {return <div />};`;
     expect(await transform(src, state)).toBe(expected);
   });
 

--- a/src/convert/private-types.test.ts
+++ b/src/convert/private-types.test.ts
@@ -17,7 +17,7 @@ describe("transform type annotations", () => {
 
   it("converts React$Element", async () => {
     const src = `const Component = (props: Props): React$Element => {return <div />};`;
-    const expected = `const Component = (props: Props): React.Element => {return <div />};`;
+    const expected = `const Component: React.FC<Props> = props => {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -29,7 +29,7 @@ describe("transform type annotations", () => {
 
   it("converts Flow namespaces", async () => {
     const src = `const Component = (props: Props): Any$Thing => {return <div />};`;
-    const expected = `const Component = (props: Props): Any.Thing => {return <div />};`;
+    const expected = `const Component: React.FC<Props> = props => {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -40,7 +40,8 @@ describe("transform type annotations", () => {
       },
     });
     const src = `const Component = (props: Props): Any$Thing => {return <div />};`;
-    expect(await transform(src, state)).toBe(src);
+    const expected = `const Component: React.FC<Props> = props => {return <div />};`;
+    expect(await transform(src, state)).toBe(expected);
   });
 
   it("Converts private types in type parameter instantiations", async () => {

--- a/src/convert/transform-runners.ts
+++ b/src/convert/transform-runners.ts
@@ -11,6 +11,7 @@ import { TransformerInput, Transformer } from "./transformer";
 import { transformTypeAnnotations } from "./type-annotations";
 import { removeFlowComments } from "./remove-flow-comments";
 import { annotateNoFlow } from "./annotate-no-flow";
+import { transformFunctionalComponents } from "./functional-components";
 
 const standardTransformRunnerFactory = (transformer: Transformer) => {
   return (transformerInput: TransformerInput) => {
@@ -59,3 +60,9 @@ export const removeFlowCommentTransformRunner: Transformer =
 
 export const annotateNoFlowTransformRunner: Transformer =
   standardTransformRunnerFactory(annotateNoFlow);
+
+export const functionalComponentTransformerRunner: Transformer = async (
+  transformerInput: TransformerInput
+) => {
+  await transformFunctionalComponents(transformerInput);
+};

--- a/src/convert/type-annotations.test.ts
+++ b/src/convert/type-annotations.test.ts
@@ -369,7 +369,7 @@ describe("transform type annotations", () => {
 
   it("Converts React.Node to React.ReactElement in function return", async () => {
     const src = `const Component = (props: Props): React.Node => {return <div />};`;
-    const expected = `const Component: React.FC<Props> = props => {return <div />};`;
+    const expected = `const Component: React.FC<Props> = (props): React.ReactElement => {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -455,7 +455,7 @@ describe("transform type annotations", () => {
 
   it("Converts React.Node to React.ReactElement in arrow function", async () => {
     const src = `const Component = (props: Props): React.Node => {return <div />};`;
-    const expected = `const Component: React.FC<Props> = props => {return <div />};`;
+    const expected = `const Component: React.FC<Props> = (props): React.ReactElement => {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -464,7 +464,7 @@ describe("transform type annotations", () => {
       if (foo) return (<div />);
       return null;
     };`;
-    const expected = dedent`const Component: React.FC<Props> = props => {
+    const expected = dedent`const Component: React.FC<Props> = (props): React.ReactElement => {
       if (foo) return (<div />);
       return null;
     };`;
@@ -473,7 +473,7 @@ describe("transform type annotations", () => {
 
   it("Converts React.Node to React.ReactElement in normal function", async () => {
     const src = `function Component(props: Props): React.Node {return <div />};`;
-    const expected = `const Component: React.FC<Props> = function(props) {return <div />};`;
+    const expected = `const Component: React.FC<Props> = function(props): React.ReactElement {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -482,7 +482,7 @@ describe("transform type annotations", () => {
       if (foo) return (<div />);
       return null;
     };`;
-    const expected = dedent`const Component: React.FC<Props> = function(props) {
+    const expected = dedent`const Component: React.FC<Props> = function(props): React.ReactElement {
       if (foo) return (<div />);
       return null;
     };`;

--- a/src/convert/type-annotations.test.ts
+++ b/src/convert/type-annotations.test.ts
@@ -369,7 +369,7 @@ describe("transform type annotations", () => {
 
   it("Converts React.Node to React.ReactElement in function return", async () => {
     const src = `const Component = (props: Props): React.Node => {return <div />};`;
-    const expected = `const Component = (props: Props): React.ReactElement => {return <div />};`;
+    const expected = `const Component: React.FC<Props> = props => {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -455,7 +455,7 @@ describe("transform type annotations", () => {
 
   it("Converts React.Node to React.ReactElement in arrow function", async () => {
     const src = `const Component = (props: Props): React.Node => {return <div />};`;
-    const expected = `const Component = (props: Props): React.ReactElement => {return <div />};`;
+    const expected = `const Component: React.FC<Props> = props => {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -464,7 +464,7 @@ describe("transform type annotations", () => {
       if (foo) return (<div />);
       return null;
     };`;
-    const expected = dedent`const Component = (props: Props): React.ReactElement | null => {
+    const expected = dedent`const Component: React.FC<Props> = props => {
       if (foo) return (<div />);
       return null;
     };`;
@@ -473,7 +473,7 @@ describe("transform type annotations", () => {
 
   it("Converts React.Node to React.ReactElement in normal function", async () => {
     const src = `function Component(props: Props): React.Node {return <div />};`;
-    const expected = `function Component(props: Props): React.ReactElement {return <div />};`;
+    const expected = `const Component: React.FC<Props> = function(props) {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -482,7 +482,7 @@ describe("transform type annotations", () => {
       if (foo) return (<div />);
       return null;
     };`;
-    const expected = dedent`function Component(props: Props): React.ReactElement | null {
+    const expected = dedent`const Component: React.FC<Props> = function(props) {
       if (foo) return (<div />);
       return null;
     };`;

--- a/src/convert/utils/common.ts
+++ b/src/convert/utils/common.ts
@@ -213,6 +213,28 @@ export function replaceWith(
 }
 
 /**
+ * Recast uses a different format for comments. We need to manually copy them over to the first
+ * new node in the array of nodes that was passed to us.
+ * We also attach the old location so that Recast prints it at the same place.
+ *
+ * https://github.com/benjamn/recast/issues/572
+ */
+export function replaceWithMultiple(
+  path: NodePath<t.Node>,
+  nodes: t.Node[],
+  filePath: string,
+  reporter: MigrationReporter
+) {
+  inheritLocAndComments(path.node, nodes[0]);
+  try {
+    path.replaceWithMultiple(nodes);
+  } catch (e) {
+    // Catch the error so conversion of the file can continue.
+    reporter.error(filePath, e);
+  }
+}
+
+/**
  * Tries to return the nearest LOC, and returns a default if not found.
  */
 export function getLoc<TNodeType extends t.Node>(


### PR DESCRIPTION
## Summary:
When research HOC patterns I discovered that `const Comp = (props: Props) => {}` does not work with HOCs in TS.  `const Comp: React.FC<Props> = (props) => {}` does.  In order to ensure that all of our functional components work with HOCs I'm updating the codemod to convert functional components to use `React.FC<Props>`.

Issue: FEI-4976

TODO:
- [x] handle `export default function Comp(props: Props) {}`

## Test plan:
- yarn test