### PR TITLE
Convert indexed access types

### DIFF
--- a/src/convert/migrate/type.ts
+++ b/src/convert/migrate/type.ts
@@ -977,6 +977,13 @@ function actuallyMigrateType(
 
       return t.tsUndefinedKeyword();
 
+    case "IndexedAccessType": {
+      const objectType = migrateType(reporter, state, flowType.objectType);
+      const indexType = migrateType(reporter, state, flowType.indexType);
+
+      return t.tsIndexedAccessType(objectType, indexType);
+    }
+
     default: {
       const never: { type: string } = flowType;
       reporter.unhandledFlowInputNode(

--- a/src/convert/type-annotations.test.ts
+++ b/src/convert/type-annotations.test.ts
@@ -911,4 +911,10 @@ class C {
       expect(await transform(src)).toBe(expected);
     });
   });
+
+  it("Converts indexed access types", async () => {
+    const src = `type Foo = Obj["Foo"];`;
+    const expected = `type Foo = Obj['Foo'];`;
+    expect(await transform(src)).toBe(expected);
+  });
 });


### PR DESCRIPTION
## Summary:
We use indexed access types in a bunch of our code but the codemod didn't support converting them.  This PR adds support for this.

Issue: None

## Test plan:
- yarn test type-annotations.test.ts