### PR TITLE
FEI-5037: Convert `_<sub_type>.js(x)` to `.<sub_type>.ts(x)`

### DIFF
--- a/src/runner/process-batch.ts
+++ b/src/runner/process-batch.ts
@@ -113,8 +113,11 @@ export async function processBatchAsync(
               );
 
         const tsFilePath = targetFilePath
-          .replace(/\.jsx?$/, state.hasJsx || options.forceTSX ? ".tsx" : ".ts")
-          .replace("_test.", ".test.");
+          .replace(/_([^\.]+)\.(jsx?)$/, ".$1.$2")
+          .replace(
+            /\.jsx?$/,
+            state.hasJsx || options.forceTSX ? ".tsx" : ".ts"
+          );
 
         if (isTestFile) {
           const fileName = path.basename(filePath);

--- a/src/runner/process-batch.ts
+++ b/src/runner/process-batch.ts
@@ -112,10 +112,9 @@ export async function processBatchAsync(
                 path.normalize(options.target)
               );
 
-        const tsFilePath = targetFilePath.replace(
-          /\.jsx?$/,
-          state.hasJsx || options.forceTSX ? ".tsx" : ".ts"
-        );
+        const tsFilePath = targetFilePath
+          .replace(/\.jsx?$/, state.hasJsx || options.forceTSX ? ".tsx" : ".ts")
+          .replace("_test.", ".test.");
 
         if (isTestFile) {
           const fileName = path.basename(filePath);


### PR DESCRIPTION
## Summary:
This change implements the naming convertion we want for file sub-types as described in ADR #623.  There are no tests associated with this b/c it would take a fair amount of work to standup an integration test suite to test this.  We only need these ttool for a couple handfuls of codebases.  If we notice an issue when running this on a codebase, we can tweak the logic at that point.

Issue: FEI-5037

TODO:
- [x] make this more general

## Test plan:
I tested the regex manually in node:
```
> "foo_test.js".replace(/_([^\.]+)\.(jsx?)$/, ".$1.$2")
'foo.test.js'
> "foo_testdata.jsx".replace(/_([^\.]+)\.(jsx?)$/, ".$1.$2")
'foo.testdata.jsx'
```