### PR TITLE
Ouptut ReactElement<any> to improve flowgen output

### DIFF
--- a/src/convert/declarations.test.ts
+++ b/src/convert/declarations.test.ts
@@ -524,7 +524,7 @@ describe("transform declarations", () => {
       render(): React.Node {return <div />};
     };`;
     const expected = dedent`class Foo extends React.Component {
-      render(): React.ReactElement {return <div />};
+      render(): React.ReactElement<any> {return <div />};
     };`;
     expect(await transform(src)).toBe(expected);
   });
@@ -537,7 +537,7 @@ describe("transform declarations", () => {
       };
     };`;
     const expected = dedent`class Foo extends React.Component {
-      render(): React.ReactElement | null {
+      render(): React.ReactElement<any> | null {
         if (foo) return (<div />);
         return null;
       };
@@ -550,7 +550,7 @@ describe("transform declarations", () => {
       render = (): React.Node => {return <div />};
     };`;
     const expected = dedent`class Foo extends React.Component {
-      render = (): React.ReactElement => {return <div />};
+      render = (): React.ReactElement<any> => {return <div />};
     };`;
     expect(await transform(src)).toBe(expected);
   });

--- a/src/convert/functional-components.test.ts
+++ b/src/convert/functional-components.test.ts
@@ -9,21 +9,21 @@ describe("Converting functional components", () => {
     it("adds React.FC<Props> type annotation, removes Props type annotation", async () => {
       const src = `const Comp = (props: Props) => { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp: React.FC<Props> = (props): React.ReactElement => { return <h1>Hello</h1> };"`
+        `"const Comp: React.FC<Props> = (props): React.ReactElement<any> => { return <h1>Hello</h1> };"`
       );
     });
 
     it("works with FooProps", async () => {
       const src = `const Comp = (props: FooProps) => { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp: React.FC<FooProps> = (props): React.ReactElement => { return <h1>Hello</h1> };"`
+        `"const Comp: React.FC<FooProps> = (props): React.ReactElement<any> => { return <h1>Hello</h1> };"`
       );
     });
 
     it("works on lambdas", async () => {
       const src = `const Comp = (props: FooProps) => <h1>Hello</h1>;`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp: React.FC<FooProps> = (props): React.ReactElement => <h1>Hello</h1>;"`
+        `"const Comp: React.FC<FooProps> = (props): React.ReactElement<any> => <h1>Hello</h1>;"`
       );
     });
 
@@ -35,7 +35,7 @@ describe("Converting functional components", () => {
             foo,
             bar,
           },
-        ): React.ReactElement => { return <h1>Hello</h1> };"
+        ): React.ReactElement<any> => { return <h1>Hello</h1> };"
       `);
     });
 
@@ -45,7 +45,7 @@ describe("Converting functional components", () => {
         "const Comp: React.FC<{
           foo: string,
           bar: string
-        }> = (props): React.ReactElement => { return <h1>Hello</h1> };"
+        }> = (props): React.ReactElement<any> => { return <h1>Hello</h1> };"
       `);
     });
 
@@ -55,8 +55,8 @@ describe("Converting functional components", () => {
         return <InnerComp />;
       }`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const OuterComp: React.FC<OuterProps> = (props): React.ReactElement => {
-          const InnnerComp: React.FC<InnerProps> = (props): React.ReactElement => <h1>Hello</h1>;
+        "const OuterComp: React.FC<OuterProps> = (props): React.ReactElement<any> => {
+          const InnnerComp: React.FC<InnerProps> = (props): React.ReactElement<any> => <h1>Hello</h1>;
           return <InnerComp />;
         }"
       `);
@@ -67,14 +67,14 @@ describe("Converting functional components", () => {
     it("adds React.FC<Props> type annotation, removes Props type annotation", async () => {
       const src = `const Comp = function (props: Props) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp: React.FC<Props> = function(props): React.ReactElement { return <h1>Hello</h1> };"`
+        `"const Comp: React.FC<Props> = function(props): React.ReactElement<any> { return <h1>Hello</h1> };"`
       );
     });
 
     it("works with FooProps", async () => {
       const src = `const Comp = function (props: FooProps) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp: React.FC<FooProps> = function(props): React.ReactElement { return <h1>Hello</h1> };"`
+        `"const Comp: React.FC<FooProps> = function(props): React.ReactElement<any> { return <h1>Hello</h1> };"`
       );
     });
 
@@ -86,7 +86,7 @@ describe("Converting functional components", () => {
             foo,
             bar,
           },
-        ): React.ReactElement { return <h1>Hello</h1> };"
+        ): React.ReactElement<any> { return <h1>Hello</h1> };"
       `);
     });
 
@@ -96,7 +96,7 @@ describe("Converting functional components", () => {
         "const Comp: React.FC<{
           foo: string,
           bar: string
-        }> = function(props): React.ReactElement { return <h1>Hello</h1> };"
+        }> = function(props): React.ReactElement<any> { return <h1>Hello</h1> };"
       `);
     });
 
@@ -106,8 +106,8 @@ describe("Converting functional components", () => {
         return <InnerComp />;
       }`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const OuterComp: React.FC<OuterProps> = function(props): React.ReactElement {
-          const InnnerComp: React.FC<InnerProps> = function(props): React.ReactElement { return <h1>Hello</h1>; };
+        "const OuterComp: React.FC<OuterProps> = function(props): React.ReactElement<any> {
+          const InnnerComp: React.FC<InnerProps> = function(props): React.ReactElement<any> { return <h1>Hello</h1>; };
           return <InnerComp />;
         }"
       `);
@@ -118,14 +118,14 @@ describe("Converting functional components", () => {
     it("converts it to an function expression", async () => {
       const src = `function Comp(props: Props) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp: React.FC<Props> = function(props): React.ReactElement { return <h1>Hello</h1> };"`
+        `"const Comp: React.FC<Props> = function(props): React.ReactElement<any> { return <h1>Hello</h1> };"`
       );
     });
 
     it("works with FooProps", async () => {
       const src = `function Comp(props: FooProps) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp: React.FC<FooProps> = function(props): React.ReactElement { return <h1>Hello</h1> };"`
+        `"const Comp: React.FC<FooProps> = function(props): React.ReactElement<any> { return <h1>Hello</h1> };"`
       );
     });
 
@@ -137,7 +137,7 @@ describe("Converting functional components", () => {
             foo,
             bar,
           },
-        ): React.ReactElement { return <h1>Hello</h1> };"
+        ): React.ReactElement<any> { return <h1>Hello</h1> };"
       `);
     });
 
@@ -147,7 +147,7 @@ describe("Converting functional components", () => {
         "const Comp: React.FC<{
           foo: string,
           bar: string
-        }> = function(props): React.ReactElement { return <h1>Hello</h1> };"
+        }> = function(props): React.ReactElement<any> { return <h1>Hello</h1> };"
       `);
     });
 
@@ -157,8 +157,8 @@ describe("Converting functional components", () => {
         return <InnerComp />;
       }`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const OuterComp: React.FC<OuterProps> = function(props): React.ReactElement {
-          const InnnerComp: React.FC<InnerProps> = function(props): React.ReactElement { return <h1>Hello</h1>; };
+        "const OuterComp: React.FC<OuterProps> = function(props): React.ReactElement<any> {
+          const InnnerComp: React.FC<InnerProps> = function(props): React.ReactElement<any> { return <h1>Hello</h1>; };
           return <InnerComp />;
         };"
       `);
@@ -169,14 +169,14 @@ describe("Converting functional components", () => {
     it("handles named exports", async () => {
       const src = `export function Comp(props: Props) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"export const Comp: React.FC<Props> = function(props): React.ReactElement { return <h1>Hello</h1> };;"`
+        `"export const Comp: React.FC<Props> = function(props): React.ReactElement<any> { return <h1>Hello</h1> };;"`
       );
     });
 
     it("handles default exports with props param", async () => {
       const src = `export default function Comp(props: Props) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const Comp: React.FC<Props> = function(props): React.ReactElement { return <h1>Hello</h1> };
+        "const Comp: React.FC<Props> = function(props): React.ReactElement<any> { return <h1>Hello</h1> };
         export default Comp;"
       `);
     });
@@ -187,7 +187,7 @@ describe("Converting functional components", () => {
         "const Comp: React.FC<{
           foo: string,
           bar: string
-        }> = function(props): React.ReactElement { return <h1>Hello</h1> };
+        }> = function(props): React.ReactElement<any> { return <h1>Hello</h1> };
         export default Comp;"
       `);
     });
@@ -200,7 +200,7 @@ describe("Converting functional components", () => {
             foo,
             bar,
           },
-        ): React.ReactElement { return <h1>Hello</h1> };
+        ): React.ReactElement<any> { return <h1>Hello</h1> };
         export default Comp;"
       `);
     });

--- a/src/convert/functional-components.ts
+++ b/src/convert/functional-components.ts
@@ -196,7 +196,8 @@ function createReturnType() {
         // actual return type of `React.FC<>` is `React.ReactElement | null`.
         t.identifier("React"),
         t.identifier("ReactElement")
-      )
+      ),
+      t.tsTypeParameterInstantiation([t.tsAnyKeyword()])
     )
   );
 }

--- a/src/convert/jsx-spread/jsx-spread.test.ts
+++ b/src/convert/jsx-spread/jsx-spread.test.ts
@@ -296,7 +296,7 @@ describe("transform spread JSX attributes", () => {
       foo: number
     };
 
-    const Foobar: React.FC<Props> = function(x): React.ReactElement { 
+    const Foobar: React.FC<Props> = function(x): React.ReactElement<any> { 
       const { it, ...rest } = x;
       const El = Mine;
       return <El it={it} {...rest} />

--- a/src/convert/migrate/type.ts
+++ b/src/convert/migrate/type.ts
@@ -555,7 +555,11 @@ function actuallyMigrateType(
           );
         }
         const reactElement = t.tsTypeReference(
-          t.tsQualifiedName(t.identifier("React"), t.identifier("ReactElement"))
+          t.tsQualifiedName(
+            t.identifier("React"),
+            t.identifier("ReactElement")
+          ),
+          t.tsTypeParameterInstantiation([t.tsAnyKeyword()])
         );
         if (hasNull) {
           return t.tsUnionType([reactElement, t.tsNullKeyword()]);

--- a/src/convert/private-types.test.ts
+++ b/src/convert/private-types.test.ts
@@ -17,7 +17,7 @@ describe("transform type annotations", () => {
 
   it("converts React$Element", async () => {
     const src = `const Component = (props: Props): React$Element => {return <div />};`;
-    const expected = `const Component: React.FC<Props> = (props): React.ReactElement => {return <div />};`;
+    const expected = `const Component: React.FC<Props> = (props): React.ReactElement<any> => {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -29,7 +29,7 @@ describe("transform type annotations", () => {
 
   it("converts Flow namespaces", async () => {
     const src = `const Component = (props: Props): Any$Thing => {return <div />};`;
-    const expected = `const Component: React.FC<Props> = (props): React.ReactElement => {return <div />};`;
+    const expected = `const Component: React.FC<Props> = (props): React.ReactElement<any> => {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -40,7 +40,7 @@ describe("transform type annotations", () => {
       },
     });
     const src = `const Component = (props: Props): Any$Thing => {return <div />};`;
-    const expected = `const Component: React.FC<Props> = (props): React.ReactElement => {return <div />};`;
+    const expected = `const Component: React.FC<Props> = (props): React.ReactElement<any> => {return <div />};`;
     expect(await transform(src, state)).toBe(expected);
   });
 

--- a/src/convert/type-annotations.test.ts
+++ b/src/convert/type-annotations.test.ts
@@ -369,7 +369,7 @@ describe("transform type annotations", () => {
 
   it("Converts React.Node to React.ReactElement in function return", async () => {
     const src = `const Component = (props: Props): React.Node => {return <div />};`;
-    const expected = `const Component: React.FC<Props> = (props): React.ReactElement => {return <div />};`;
+    const expected = `const Component: React.FC<Props> = (props): React.ReactElement<any> => {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -443,7 +443,7 @@ describe("transform type annotations", () => {
 
   it("Converts React.MixedElement", async () => {
     const src = `function f(): React.MixedElement {};`;
-    const expected = `function f(): React.ReactElement {};`;
+    const expected = `function f(): React.ReactElement<any> {};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -455,7 +455,7 @@ describe("transform type annotations", () => {
 
   it("Converts React.Node to React.ReactElement in arrow function", async () => {
     const src = `const Component = (props: Props): React.Node => {return <div />};`;
-    const expected = `const Component: React.FC<Props> = (props): React.ReactElement => {return <div />};`;
+    const expected = `const Component: React.FC<Props> = (props): React.ReactElement<any> => {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -464,7 +464,7 @@ describe("transform type annotations", () => {
       if (foo) return (<div />);
       return null;
     };`;
-    const expected = dedent`const Component: React.FC<Props> = (props): React.ReactElement => {
+    const expected = dedent`const Component: React.FC<Props> = (props): React.ReactElement<any> => {
       if (foo) return (<div />);
       return null;
     };`;
@@ -473,7 +473,7 @@ describe("transform type annotations", () => {
 
   it("Converts React.Node to React.ReactElement in normal function", async () => {
     const src = `function Component(props: Props): React.Node {return <div />};`;
-    const expected = `const Component: React.FC<Props> = function(props): React.ReactElement {return <div />};`;
+    const expected = `const Component: React.FC<Props> = function(props): React.ReactElement<any> {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -482,7 +482,7 @@ describe("transform type annotations", () => {
       if (foo) return (<div />);
       return null;
     };`;
-    const expected = dedent`const Component: React.FC<Props> = function(props): React.ReactElement {
+    const expected = dedent`const Component: React.FC<Props> = function(props): React.ReactElement<any> {
       if (foo) return (<div />);
       return null;
     };`;


### PR DESCRIPTION
## Summary:
ReactElement's type params are optional with the first one, P, defaulting to 'any'.  In TS it's okay to completely drop optional type params so the codemod was outputting a bunch of React.ReactElement types without any type params.  During the TypeScript migration we are generating Flow types from TypeScript types using a tool called flowgen.  This tool doesn't known about this default and was converting React.ReactElement to React.Element<> which is not valid in Flow b/c the type parameter is required.  This PR fixes the issue by ensuring that we output React.ReactElement<any>.  While this isn't required for TypeScript it is used by flowgen to output the correct types for Flow.

Issue: None

## Test plan:
- yarn test