### PR TITLE
FEI-5071: Fix output paths for _test.js etc.

### DIFF
--- a/src/runner/process-batch.ts
+++ b/src/runner/process-batch.ts
@@ -113,7 +113,7 @@ export async function processBatchAsync(
               );
 
         const tsFilePath = targetFilePath
-          .replace(/_([^\.]+)\.(jsx?)$/, ".$1.$2")
+          .replace(/(__[^_]+__\/)?(.*)_([^\.]+)\.(jsx?)$/, "$1$2.$3.$4")
           .replace(
             /\.jsx?$/,
             state.hasJsx || options.forceTSX ? ".tsx" : ".ts"


### PR DESCRIPTION
## Summary:
The previous regex got tripped up by out `__tests__` folders and output `._tests__/foo_test.js` instead of `__tests/foo.test.js`.  This PR fixes this issue.

Issue: FEI-5071

## Test plan:
In the browser's dev console check that the regex and replace works as expected
![Screen Shot 2023-03-31 at 5 20 24 PM](https://user-images.githubusercontent.com/1044413/229235156-ba53604b-009d-4d77-b017-709f59713d4b.png)
