### PR TITLE
FEI-5074: Don't use React.FC<> when converting function components

### DIFF
--- a/src/convert/functional-components.test.ts
+++ b/src/convert/functional-components.test.ts
@@ -9,28 +9,28 @@ describe("Converting functional components", () => {
     it("adds React.FC<Props> type annotation, removes Props type annotation", async () => {
       const src = `const Comp = (props: Props) => { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp: React.FC<Props> = (props): React.ReactElement => { return <h1>Hello</h1> };"`
+        `"const Comp = (props): React.ReactElement => { return <h1>Hello</h1> };"`
       );
     });
 
     it("works with FooProps", async () => {
       const src = `const Comp = (props: FooProps) => { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp: React.FC<FooProps> = (props): React.ReactElement => { return <h1>Hello</h1> };"`
+        `"const Comp = (props): React.ReactElement => { return <h1>Hello</h1> };"`
       );
     });
 
     it("works on lambdas", async () => {
       const src = `const Comp = (props: FooProps) => <h1>Hello</h1>;`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp: React.FC<FooProps> = (props): React.ReactElement => <h1>Hello</h1>;"`
+        `"const Comp = (props): React.ReactElement => <h1>Hello</h1>;"`
       );
     });
 
     it("works with destructured props", async () => {
       const src = `const Comp = ({foo, bar}: Props) => { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const Comp: React.FC<Props> = (
+        "const Comp = (
           {
             foo,
             bar,
@@ -41,12 +41,9 @@ describe("Converting functional components", () => {
 
     it("works on functions with inline props type and React.Node return type", async () => {
       const src = `const Comp = (props: {|foo: string, bar: string|}): React.Node => { return <h1>Hello</h1> };`;
-      expect(await transform(src)).toMatchInlineSnapshot(`
-        "const Comp: React.FC<{
-          foo: string,
-          bar: string
-        }> = (props): React.ReactElement => { return <h1>Hello</h1> };"
-      `);
+      expect(await transform(src)).toMatchInlineSnapshot(
+        `"const Comp = (props): React.ReactElement => { return <h1>Hello</h1> };"`
+      );
     });
 
     it("works with components defined within another function", async () => {
@@ -55,8 +52,8 @@ describe("Converting functional components", () => {
         return <InnerComp />;
       }`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const OuterComp: React.FC<OuterProps> = (props): React.ReactElement => {
-          const InnnerComp: React.FC<InnerProps> = (props): React.ReactElement => <h1>Hello</h1>;
+        "const OuterComp = (props): React.ReactElement => {
+          const InnnerComp = (props): React.ReactElement => <h1>Hello</h1>;
           return <InnerComp />;
         }"
       `);
@@ -67,21 +64,21 @@ describe("Converting functional components", () => {
     it("adds React.FC<Props> type annotation, removes Props type annotation", async () => {
       const src = `const Comp = function (props: Props) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp: React.FC<Props> = function(props): React.ReactElement { return <h1>Hello</h1> };"`
+        `"const Comp = function(props): React.ReactElement { return <h1>Hello</h1> };"`
       );
     });
 
     it("works with FooProps", async () => {
       const src = `const Comp = function (props: FooProps) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp: React.FC<FooProps> = function(props): React.ReactElement { return <h1>Hello</h1> };"`
+        `"const Comp = function(props): React.ReactElement { return <h1>Hello</h1> };"`
       );
     });
 
     it("works with destructured props", async () => {
       const src = `const Comp = function ({foo, bar}: Props) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const Comp: React.FC<Props> = function(
+        "const Comp = function(
           {
             foo,
             bar,
@@ -92,12 +89,9 @@ describe("Converting functional components", () => {
 
     it("works on functions with inline props type and React.Node return type", async () => {
       const src = `const Comp = function (props: {|foo: string, bar: string|}): React.Node { return <h1>Hello</h1> };`;
-      expect(await transform(src)).toMatchInlineSnapshot(`
-        "const Comp: React.FC<{
-          foo: string,
-          bar: string
-        }> = function(props): React.ReactElement { return <h1>Hello</h1> };"
-      `);
+      expect(await transform(src)).toMatchInlineSnapshot(
+        `"const Comp = function(props): React.ReactElement { return <h1>Hello</h1> };"`
+      );
     });
 
     it("works with components defined within another function", async () => {
@@ -106,8 +100,8 @@ describe("Converting functional components", () => {
         return <InnerComp />;
       }`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const OuterComp: React.FC<OuterProps> = function(props): React.ReactElement {
-          const InnnerComp: React.FC<InnerProps> = function(props): React.ReactElement { return <h1>Hello</h1>; };
+        "const OuterComp = function(props): React.ReactElement {
+          const InnnerComp = function(props): React.ReactElement { return <h1>Hello</h1>; };
           return <InnerComp />;
         }"
       `);
@@ -118,21 +112,21 @@ describe("Converting functional components", () => {
     it("converts it to an function expression", async () => {
       const src = `function Comp(props: Props) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp: React.FC<Props> = function(props): React.ReactElement { return <h1>Hello</h1> };"`
+        `"const Comp = function(props): React.ReactElement { return <h1>Hello</h1> };"`
       );
     });
 
     it("works with FooProps", async () => {
       const src = `function Comp(props: FooProps) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp: React.FC<FooProps> = function(props): React.ReactElement { return <h1>Hello</h1> };"`
+        `"const Comp = function(props): React.ReactElement { return <h1>Hello</h1> };"`
       );
     });
 
     it("works with destructured props", async () => {
       const src = `function Comp({foo, bar}: Props) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const Comp: React.FC<Props> = function(
+        "const Comp = function(
           {
             foo,
             bar,
@@ -143,12 +137,9 @@ describe("Converting functional components", () => {
 
     it("works on functions with inline props type and React.Node return type", async () => {
       const src = `function Comp(props: {|foo: string, bar: string|}): React.Node { return <h1>Hello</h1> };`;
-      expect(await transform(src)).toMatchInlineSnapshot(`
-        "const Comp: React.FC<{
-          foo: string,
-          bar: string
-        }> = function(props): React.ReactElement { return <h1>Hello</h1> };"
-      `);
+      expect(await transform(src)).toMatchInlineSnapshot(
+        `"const Comp = function(props): React.ReactElement { return <h1>Hello</h1> };"`
+      );
     });
 
     it("works with components defined within another function", async () => {
@@ -157,8 +148,8 @@ describe("Converting functional components", () => {
         return <InnerComp />;
       }`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const OuterComp: React.FC<OuterProps> = function(props): React.ReactElement {
-          const InnnerComp: React.FC<InnerProps> = function(props): React.ReactElement { return <h1>Hello</h1>; };
+        "const OuterComp = function(props): React.ReactElement {
+          const InnnerComp = function(props): React.ReactElement { return <h1>Hello</h1>; };
           return <InnerComp />;
         };"
       `);
@@ -169,14 +160,14 @@ describe("Converting functional components", () => {
     it("handles named exports", async () => {
       const src = `export function Comp(props: Props) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"export const Comp: React.FC<Props> = function(props): React.ReactElement { return <h1>Hello</h1> };;"`
+        `"export const Comp = function(props): React.ReactElement { return <h1>Hello</h1> };;"`
       );
     });
 
     it("handles default exports with props param", async () => {
       const src = `export default function Comp(props: Props) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const Comp: React.FC<Props> = function(props): React.ReactElement { return <h1>Hello</h1> };
+        "const Comp = function(props): React.ReactElement { return <h1>Hello</h1> };
         export default Comp;"
       `);
     });
@@ -184,10 +175,7 @@ describe("Converting functional components", () => {
     it("handles default exports with inline props", async () => {
       const src = `export default function Comp(props: {|foo: string, bar: string|}): React.Node { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const Comp: React.FC<{
-          foo: string,
-          bar: string
-        }> = function(props): React.ReactElement { return <h1>Hello</h1> };
+        "const Comp = function(props): React.ReactElement { return <h1>Hello</h1> };
         export default Comp;"
       `);
     });
@@ -195,7 +183,7 @@ describe("Converting functional components", () => {
     it("handles default exports with destructured props", async () => {
       const src = `export default function Comp({foo, bar}: Props): React.Node { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const Comp: React.FC<Props> = function(
+        "const Comp = function(
           {
             foo,
             bar,

--- a/src/convert/functional-components.ts
+++ b/src/convert/functional-components.ts
@@ -51,13 +51,6 @@ export function transformFunctionalComponents({
                   arrowFn.returnType.typeAnnotation.typeName.right.name
                 ))
             ) {
-              // HACK(kevinb): We mutate the nodes directly instead of using `replaceWith`
-              // because that function will end up in an infinite loop if we try to pass
-              // it a node that contains any descendent nodes of the original node.
-              id.typeAnnotation = createReactFcType(
-                param.typeAnnotation.typeAnnotation
-              );
-
               // We always include a return type so that the output code conforms to
               // https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/2201682700/TypeScript+Best+Practices#Functions-should-have-return-types
               arrowFn.returnType = createReturnType();
@@ -96,13 +89,6 @@ export function transformFunctionalComponents({
                   returnType.typeAnnotation.typeName.right.name
                 ))
             ) {
-              // HACK(kevinb): We mutate the nodes directly instead of using `replaceWith`
-              // because that function will end up in an infinite loop if we try to pass
-              // it a node that contains any descendent nodes of the original node.
-              id.typeAnnotation = createReactFcType(
-                param.typeAnnotation.typeAnnotation
-              );
-
               const fn = t.functionExpression(null, params, body);
 
               // We always include a return type so that the output code conforms to
@@ -151,13 +137,6 @@ export function transformFunctionalComponents({
                   returnType.typeAnnotation.typeName.right.name
                 ))
             ) {
-              // HACK(kevinb): We mutate the nodes directly instead of using `replaceWith`
-              // because that function will end up in an infinite loop if we try to pass
-              // it a node that contains any descendent nodes of the original node.
-              id.typeAnnotation = createReactFcType(
-                param.typeAnnotation.typeAnnotation
-              );
-
               const fn = t.functionExpression(null, params, body);
 
               // We always include a return type so that the output code conforms to
@@ -197,15 +176,6 @@ function createReturnType() {
         t.identifier("React"),
         t.identifier("ReactElement")
       )
-    )
-  );
-}
-
-function createReactFcType(propsType: t.TSType) {
-  return t.tsTypeAnnotation(
-    t.tsTypeReference(
-      t.tsQualifiedName(t.identifier("React"), t.identifier("FC")),
-      t.tsTypeParameterInstantiation([propsType])
     )
   );
 }

--- a/src/convert/jsx-spread/jsx-spread.test.ts
+++ b/src/convert/jsx-spread/jsx-spread.test.ts
@@ -296,7 +296,7 @@ describe("transform spread JSX attributes", () => {
       foo: number
     };
 
-    const Foobar: React.FC<Props> = function(x): React.ReactElement { 
+    const Foobar = function(x): React.ReactElement { 
       const { it, ...rest } = x;
       const El = Mine;
       return <El it={it} {...rest} />

--- a/src/convert/private-types.test.ts
+++ b/src/convert/private-types.test.ts
@@ -17,7 +17,7 @@ describe("transform type annotations", () => {
 
   it("converts React$Element", async () => {
     const src = `const Component = (props: Props): React$Element => {return <div />};`;
-    const expected = `const Component: React.FC<Props> = (props): React.ReactElement => {return <div />};`;
+    const expected = `const Component = (props): React.ReactElement => {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -29,7 +29,7 @@ describe("transform type annotations", () => {
 
   it("converts Flow namespaces", async () => {
     const src = `const Component = (props: Props): Any$Thing => {return <div />};`;
-    const expected = `const Component: React.FC<Props> = (props): React.ReactElement => {return <div />};`;
+    const expected = `const Component = (props): React.ReactElement => {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -40,7 +40,7 @@ describe("transform type annotations", () => {
       },
     });
     const src = `const Component = (props: Props): Any$Thing => {return <div />};`;
-    const expected = `const Component: React.FC<Props> = (props): React.ReactElement => {return <div />};`;
+    const expected = `const Component = (props): React.ReactElement => {return <div />};`;
     expect(await transform(src, state)).toBe(expected);
   });
 

--- a/src/convert/type-annotations.test.ts
+++ b/src/convert/type-annotations.test.ts
@@ -369,7 +369,7 @@ describe("transform type annotations", () => {
 
   it("Converts React.Node to React.ReactElement in function return", async () => {
     const src = `const Component = (props: Props): React.Node => {return <div />};`;
-    const expected = `const Component: React.FC<Props> = (props): React.ReactElement => {return <div />};`;
+    const expected = `const Component = (props): React.ReactElement => {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -455,7 +455,7 @@ describe("transform type annotations", () => {
 
   it("Converts React.Node to React.ReactElement in arrow function", async () => {
     const src = `const Component = (props: Props): React.Node => {return <div />};`;
-    const expected = `const Component: React.FC<Props> = (props): React.ReactElement => {return <div />};`;
+    const expected = `const Component = (props): React.ReactElement => {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -464,7 +464,7 @@ describe("transform type annotations", () => {
       if (foo) return (<div />);
       return null;
     };`;
-    const expected = dedent`const Component: React.FC<Props> = (props): React.ReactElement => {
+    const expected = dedent`const Component = (props): React.ReactElement => {
       if (foo) return (<div />);
       return null;
     };`;
@@ -473,7 +473,7 @@ describe("transform type annotations", () => {
 
   it("Converts React.Node to React.ReactElement in normal function", async () => {
     const src = `function Component(props: Props): React.Node {return <div />};`;
-    const expected = `const Component: React.FC<Props> = function(props): React.ReactElement {return <div />};`;
+    const expected = `const Component = function(props): React.ReactElement {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -482,7 +482,7 @@ describe("transform type annotations", () => {
       if (foo) return (<div />);
       return null;
     };`;
-    const expected = dedent`const Component: React.FC<Props> = function(props): React.ReactElement {
+    const expected = dedent`const Component = function(props): React.ReactElement {
       if (foo) return (<div />);
       return null;
     };`;


### PR DESCRIPTION
## Summary:
The use of React.FC<> is discouraged for a few reasons:
- it adds an implicit 'children' prop even if the component doesn't need it
- it allows .defaultProps to be defined on functional components and we'd rather people be setting defaults when destructuring props (it makes the types less confusing)

Issue: FEI-5074

## Test plan:
- yarn test