### PR TITLE
FEI-5075: Don't add ReactElement return type for non-component functions

### DIFF
--- a/src/convert/functional-components.test.ts
+++ b/src/convert/functional-components.test.ts
@@ -9,21 +9,21 @@ describe("Converting functional components", () => {
     it("adds React.FC<Props> type annotation, removes Props type annotation", async () => {
       const src = `const Comp = (props: Props) => { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp = (props): React.ReactElement => { return <h1>Hello</h1> };"`
+        `"const Comp = (props: Props): React.ReactElement => { return <h1>Hello</h1> };"`
       );
     });
 
     it("works with FooProps", async () => {
       const src = `const Comp = (props: FooProps) => { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp = (props): React.ReactElement => { return <h1>Hello</h1> };"`
+        `"const Comp = (props: FooProps): React.ReactElement => { return <h1>Hello</h1> };"`
       );
     });
 
     it("works on lambdas", async () => {
       const src = `const Comp = (props: FooProps) => <h1>Hello</h1>;`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp = (props): React.ReactElement => <h1>Hello</h1>;"`
+        `"const Comp = (props: FooProps): React.ReactElement => <h1>Hello</h1>;"`
       );
     });
 
@@ -34,26 +34,31 @@ describe("Converting functional components", () => {
           {
             foo,
             bar,
-          },
+          }: Props,
         ): React.ReactElement => { return <h1>Hello</h1> };"
       `);
     });
 
     it("works on functions with inline props type and React.Node return type", async () => {
       const src = `const Comp = (props: {|foo: string, bar: string|}): React.Node => { return <h1>Hello</h1> };`;
-      expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp = (props): React.ReactElement => { return <h1>Hello</h1> };"`
-      );
+      expect(await transform(src)).toMatchInlineSnapshot(`
+        "const Comp = (
+          props: {
+            foo: string,
+            bar: string
+          },
+        ): React.ReactElement => { return <h1>Hello</h1> };"
+      `);
     });
 
     it("works with components defined within another function", async () => {
       const src = dedent`const OuterComp = (props: OuterProps): React.Node => {
-        const InnnerComp = (props: InnerProps) => <h1>Hello</h1>;
+        const InnnerComp = (props: InnerProps): React.Node => <h1>Hello</h1>;
         return <InnerComp />;
       }`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const OuterComp = (props): React.ReactElement => {
-          const InnnerComp = (props): React.ReactElement => <h1>Hello</h1>;
+        "const OuterComp = (props: OuterProps): React.ReactElement => {
+          const InnnerComp = (props: InnerProps): React.ReactElement => <h1>Hello</h1>;
           return <InnerComp />;
         }"
       `);
@@ -64,14 +69,14 @@ describe("Converting functional components", () => {
     it("adds React.FC<Props> type annotation, removes Props type annotation", async () => {
       const src = `const Comp = function (props: Props) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp = function(props): React.ReactElement { return <h1>Hello</h1> };"`
+        `"const Comp = function(props: Props): React.ReactElement { return <h1>Hello</h1> };"`
       );
     });
 
     it("works with FooProps", async () => {
       const src = `const Comp = function (props: FooProps) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp = function(props): React.ReactElement { return <h1>Hello</h1> };"`
+        `"const Comp = function(props: FooProps): React.ReactElement { return <h1>Hello</h1> };"`
       );
     });
 
@@ -82,26 +87,32 @@ describe("Converting functional components", () => {
           {
             foo,
             bar,
-          },
+          }: Props,
         ): React.ReactElement { return <h1>Hello</h1> };"
       `);
     });
 
     it("works on functions with inline props type and React.Node return type", async () => {
       const src = `const Comp = function (props: {|foo: string, bar: string|}): React.Node { return <h1>Hello</h1> };`;
-      expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp = function(props): React.ReactElement { return <h1>Hello</h1> };"`
-      );
+      expect(await transform(src)).toMatchInlineSnapshot(`
+        "const Comp = function(
+          props: {
+            foo: string,
+            bar: string
+          },
+        ): React.ReactElement { return <h1>Hello</h1> };"
+      `);
     });
 
+    // FIXME
     it("works with components defined within another function", async () => {
       const src = dedent`const OuterComp = function (props: OuterProps): React.Node {
         const InnnerComp = function (props: InnerProps) { return <h1>Hello</h1>; };
         return <InnerComp />;
       }`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const OuterComp = function(props): React.ReactElement {
-          const InnnerComp = function(props): React.ReactElement { return <h1>Hello</h1>; };
+        "const OuterComp = function(props: OuterProps): React.ReactElement {
+          const InnnerComp = function(props: InnerProps): React.ReactElement { return <h1>Hello</h1>; };
           return <InnerComp />;
         }"
       `);
@@ -112,14 +123,14 @@ describe("Converting functional components", () => {
     it("converts it to an function expression", async () => {
       const src = `function Comp(props: Props) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp = function(props): React.ReactElement { return <h1>Hello</h1> };"`
+        `"const Comp = function(props: Props): React.ReactElement { return <h1>Hello</h1> };"`
       );
     });
 
     it("works with FooProps", async () => {
       const src = `function Comp(props: FooProps) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp = function(props): React.ReactElement { return <h1>Hello</h1> };"`
+        `"const Comp = function(props: FooProps): React.ReactElement { return <h1>Hello</h1> };"`
       );
     });
 
@@ -130,16 +141,21 @@ describe("Converting functional components", () => {
           {
             foo,
             bar,
-          },
+          }: Props,
         ): React.ReactElement { return <h1>Hello</h1> };"
       `);
     });
 
     it("works on functions with inline props type and React.Node return type", async () => {
       const src = `function Comp(props: {|foo: string, bar: string|}): React.Node { return <h1>Hello</h1> };`;
-      expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp = function(props): React.ReactElement { return <h1>Hello</h1> };"`
-      );
+      expect(await transform(src)).toMatchInlineSnapshot(`
+        "const Comp = function(
+          props: {
+            foo: string,
+            bar: string
+          },
+        ): React.ReactElement { return <h1>Hello</h1> };"
+      `);
     });
 
     it("works with components defined within another function", async () => {
@@ -148,8 +164,8 @@ describe("Converting functional components", () => {
         return <InnerComp />;
       }`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const OuterComp = function(props): React.ReactElement {
-          const InnnerComp = function(props): React.ReactElement { return <h1>Hello</h1>; };
+        "const OuterComp = function(props: OuterProps): React.ReactElement {
+          const InnnerComp = function(props: InnerProps): React.ReactElement { return <h1>Hello</h1>; };
           return <InnerComp />;
         };"
       `);
@@ -160,14 +176,14 @@ describe("Converting functional components", () => {
     it("handles named exports", async () => {
       const src = `export function Comp(props: Props) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"export const Comp = function(props): React.ReactElement { return <h1>Hello</h1> };;"`
+        `"export const Comp = function(props: Props): React.ReactElement { return <h1>Hello</h1> };;"`
       );
     });
 
     it("handles default exports with props param", async () => {
       const src = `export default function Comp(props: Props) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const Comp = function(props): React.ReactElement { return <h1>Hello</h1> };
+        "const Comp = function(props: Props): React.ReactElement { return <h1>Hello</h1> };
         export default Comp;"
       `);
     });
@@ -175,7 +191,12 @@ describe("Converting functional components", () => {
     it("handles default exports with inline props", async () => {
       const src = `export default function Comp(props: {|foo: string, bar: string|}): React.Node { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const Comp = function(props): React.ReactElement { return <h1>Hello</h1> };
+        "const Comp = function(
+          props: {
+            foo: string,
+            bar: string
+          },
+        ): React.ReactElement { return <h1>Hello</h1> };
         export default Comp;"
       `);
     });
@@ -187,10 +208,30 @@ describe("Converting functional components", () => {
           {
             foo,
             bar,
-          },
+          }: Props,
         ): React.ReactElement { return <h1>Hello</h1> };
         export default Comp;"
       `);
+    });
+  });
+});
+
+describe("Doesn't treat non-component functions as components", () => {
+  describe("Arrow functions", () => {
+    it("adds React.FC<Props> type annotation, removes Props type annotation", async () => {
+      const src = `const Comp = (props: Props) => { return {foo: props.foo, bar: props.bar}; };`;
+      expect(await transform(src)).toMatchInlineSnapshot(
+        `"const Comp = (props: Props) => { return {foo: props.foo, bar: props.bar}; };"`
+      );
+    });
+  });
+
+  describe("Exporting function", () => {
+    it("handles named exports", async () => {
+      const src = `export function Comp(props: Props) { return {foo: props.foo, bar: props.bar}; };`;
+      expect(await transform(src)).toMatchInlineSnapshot(
+        `"export function Comp(props: Props) { return {foo: props.foo, bar: props.bar}; };"`
+      );
     });
   });
 });

--- a/src/convert/functional-components.test.ts
+++ b/src/convert/functional-components.test.ts
@@ -6,7 +6,7 @@ jest.mock("./flow/type-at-pos.ts");
 
 describe("Converting functional components", () => {
   describe("Arrow functions", () => {
-    it("adds React.FC<Props> type annotation, removes Props type annotation", async () => {
+    it("adds return type annotation", async () => {
       const src = `const Comp = (props: Props) => { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
         `"const Comp = (props: Props): React.ReactElement => { return <h1>Hello</h1> };"`
@@ -66,7 +66,7 @@ describe("Converting functional components", () => {
   });
 
   describe("Anonymous function expressions", () => {
-    it("adds React.FC<Props> type annotation, removes Props type annotation", async () => {
+    it("adds return type annotation", async () => {
       const src = `const Comp = function (props: Props) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
         `"const Comp = function(props: Props): React.ReactElement { return <h1>Hello</h1> };"`
@@ -216,10 +216,10 @@ describe("Converting functional components", () => {
   });
 });
 
-describe("Doesn't treat non-component functions as components", () => {
+describe("Non-component functions as components", () => {
   describe("Arrow functions", () => {
-    it("adds React.FC<Props> type annotation, removes Props type annotation", async () => {
-      const src = `const Comp = (props: Props) => { return {foo: props.foo, bar: props.bar}; };`;
+    it("doesn't treat mapPropsToState as a component", async () => {
+      const src = `const mapPropsToState = (props: Props) => { return {foo: props.foo, bar: props.bar}; };`;
       expect(await transform(src)).toMatchInlineSnapshot(
         `"const Comp = (props: Props) => { return {foo: props.foo, bar: props.bar}; };"`
       );
@@ -227,8 +227,8 @@ describe("Doesn't treat non-component functions as components", () => {
   });
 
   describe("Exporting function", () => {
-    it("handles named exports", async () => {
-      const src = `export function Comp(props: Props) { return {foo: props.foo, bar: props.bar}; };`;
+    it("doesn't treat mapPropsToState as a component", async () => {
+      const src = `export function mapPropsToState(props: Props) { return {foo: props.foo, bar: props.bar}; };`;
       expect(await transform(src)).toMatchInlineSnapshot(
         `"export function Comp(props: Props) { return {foo: props.foo, bar: props.bar}; };"`
       );

--- a/src/convert/functional-components.ts
+++ b/src/convert/functional-components.ts
@@ -6,162 +6,232 @@ import { replaceWith, replaceWithMultiple } from "./utils/common";
 
 export function transformFunctionalComponents({
   reporter,
-  state,
+  state: globalState,
   file,
 }: TransformerInput): Promise<unknown> {
   const awaitPromises: Array<Promise<unknown>> = [];
 
-  traverse(file, {
-    VariableDeclarator: {
-      exit(path) {
-        if (
-          t.isArrowFunctionExpression(path.node.init) ||
-          t.isFunctionExpression(path.node.init)
-        ) {
-          const { id, init: arrowFn } = path.node;
-          const { params } = arrowFn;
-          if (params.length === 1) {
-            const [param] = params;
+  // We only want to add `React.ReactElement` as a return type on functions that
+  // we know are React components.  Checking if there's a param named `props` is
+  // not enough to determine this since `mapPropsToState` and `mapPropsToDispatch`
+  // both take `props` as param but are not components.  In order to determine if
+  // a function is a component, we also need to check if returns any JSX.  In order
+  // to do this, we need to track if there's any JSXElements in each scope.
+  const initialState: { scopes: Array<{ jsx: boolean }> } = { scopes: [] };
 
-            if (
-              (t.isIdentifier(id) &&
-                t.isTSTypeAnnotation(param.typeAnnotation) &&
-                t.isTSTypeReference(param.typeAnnotation.typeAnnotation) &&
-                t.isIdentifier(param.typeAnnotation.typeAnnotation.typeName) &&
-                param.typeAnnotation.typeAnnotation.typeName.name.endsWith(
-                  "Props"
-                )) ||
-              (t.isIdentifier(id) &&
-                t.isTSTypeAnnotation(param.typeAnnotation) &&
-                t.isTSTypeAnnotation(arrowFn.returnType) &&
-                t.isTSTypeReference(arrowFn.returnType.typeAnnotation) &&
-                t.isTSQualifiedName(
-                  arrowFn.returnType.typeAnnotation.typeName
-                ) &&
-                t.isIdentifier(
-                  arrowFn.returnType.typeAnnotation.typeName.left,
-                  {
+  traverse(
+    file,
+    {
+      JSXElement: {
+        exit(_, state) {
+          if (state.scopes.length > 0) {
+            state.scopes[state.scopes.length - 1].jsx = true;
+          }
+        },
+      },
+      FunctionExpression: {
+        enter(_, state) {
+          state.scopes.push({ jsx: false });
+        },
+        exit(path, state) {
+          const containsJsx = state.scopes[state.scopes.length - 1].jsx;
+          // We only want to modify the node if the function contains JSX otherwise
+          // it messes up the conversion of other functions, even if `containsJsx` is
+          // set to false.
+          if (containsJsx) {
+            // @ts-expect-error: containsJsx is a custom property we're adding
+            path.node.containsJsx = containsJsx;
+          }
+          state.scopes.pop();
+        },
+      },
+      ArrowFunctionExpression: {
+        enter(_, state) {
+          state.scopes.push({ jsx: false });
+        },
+        exit(path, state) {
+          const containsJsx = state.scopes[state.scopes.length - 1].jsx;
+          // We only want to modify the node if the function contains JSX otherwise
+          // it messes up the conversion of other functions, even if `containsJsx` is
+          // set to false.
+          if (containsJsx) {
+            // @ts-expect-error: containsJsx is a custom property we're adding
+            path.node.containsJsx = containsJsx;
+          }
+          state.scopes.pop();
+        },
+      },
+      VariableDeclarator: {
+        exit(path) {
+          if (
+            (t.isArrowFunctionExpression(path.node.init) ||
+              t.isFunctionExpression(path.node.init)) &&
+            // @ts-expect-error: containsJsx is a custom property we're adding
+            path.node.init.containsJsx
+          ) {
+            const { id, init: arrowFn } = path.node;
+            const { params } = arrowFn;
+            if (params.length === 1) {
+              const [param] = params;
+
+              if (
+                (t.isIdentifier(id) &&
+                  t.isTSTypeAnnotation(param.typeAnnotation) &&
+                  t.isTSTypeReference(param.typeAnnotation.typeAnnotation) &&
+                  t.isIdentifier(
+                    param.typeAnnotation.typeAnnotation.typeName
+                  ) &&
+                  param.typeAnnotation.typeAnnotation.typeName.name.endsWith(
+                    "Props"
+                  )) ||
+                (t.isIdentifier(id) &&
+                  t.isTSTypeAnnotation(param.typeAnnotation) &&
+                  t.isTSTypeAnnotation(arrowFn.returnType) &&
+                  t.isTSTypeReference(arrowFn.returnType.typeAnnotation) &&
+                  t.isTSQualifiedName(
+                    arrowFn.returnType.typeAnnotation.typeName
+                  ) &&
+                  t.isIdentifier(
+                    arrowFn.returnType.typeAnnotation.typeName.left,
+                    {
+                      name: "React",
+                    }
+                  ) &&
+                  t.isIdentifier(
+                    arrowFn.returnType.typeAnnotation.typeName.right
+                  ) &&
+                  ["ReactNode", "ReactElement"].includes(
+                    arrowFn.returnType.typeAnnotation.typeName.right.name
+                  ))
+              ) {
+                // We always include a return type so that the output code conforms to
+                // https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/2201682700/TypeScript+Best+Practices#Functions-should-have-return-types
+                arrowFn.returnType = createReturnType();
+              }
+            }
+          }
+        },
+      },
+      FunctionDeclaration: {
+        enter(_, state) {
+          state.scopes.push({ jsx: false });
+        },
+        exit(path, state) {
+          if (!t.isExportDefaultDeclaration(path.parent)) {
+            const { id, params, returnType, body } = path.node;
+            if (params.length === 1) {
+              const [param] = params;
+
+              if (
+                state.scopes.length > 0 &&
+                !state.scopes[state.scopes.length - 1].jsx
+              ) {
+                return;
+              }
+
+              if (
+                (t.isIdentifier(id) &&
+                  t.isTSTypeAnnotation(param.typeAnnotation) &&
+                  t.isTSTypeReference(param.typeAnnotation.typeAnnotation) &&
+                  t.isIdentifier(
+                    param.typeAnnotation.typeAnnotation.typeName
+                  ) &&
+                  param.typeAnnotation.typeAnnotation.typeName.name.endsWith(
+                    "Props"
+                  )) ||
+                (t.isIdentifier(id) &&
+                  t.isTSTypeAnnotation(param.typeAnnotation) &&
+                  t.isTSTypeAnnotation(returnType) &&
+                  t.isTSTypeReference(returnType.typeAnnotation) &&
+                  t.isTSQualifiedName(returnType.typeAnnotation.typeName) &&
+                  t.isIdentifier(returnType.typeAnnotation.typeName.left, {
                     name: "React",
-                  }
-                ) &&
-                t.isIdentifier(
-                  arrowFn.returnType.typeAnnotation.typeName.right
-                ) &&
-                ["ReactNode", "ReactElement"].includes(
-                  arrowFn.returnType.typeAnnotation.typeName.right.name
-                ))
-            ) {
-              // We always include a return type so that the output code conforms to
-              // https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/2201682700/TypeScript+Best+Practices#Functions-should-have-return-types
-              arrowFn.returnType = createReturnType();
+                  }) &&
+                  t.isIdentifier(returnType.typeAnnotation.typeName.right) &&
+                  ["ReactNode", "ReactElement"].includes(
+                    returnType.typeAnnotation.typeName.right.name
+                  ))
+              ) {
+                const fn = t.functionExpression(null, params, body);
 
-              delete param.typeAnnotation;
+                // We always include a return type so that the output code conforms to
+                // https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/2201682700/TypeScript+Best+Practices#Functions-should-have-return-types
+                fn.returnType = createReturnType();
+
+                replaceWith(
+                  path,
+                  t.variableDeclaration("const", [
+                    t.variableDeclarator(id, fn),
+                  ]),
+                  globalState.config.filePath,
+                  reporter
+                );
+              }
             }
           }
-        }
+
+          state.scopes.pop();
+        },
       },
-    },
-    FunctionDeclaration: {
-      exit(path) {
-        if (!t.isExportDefaultDeclaration(path.parent)) {
-          const { id, params, returnType, body } = path.node;
-          if (params.length === 1) {
-            const [param] = params;
+      ExportDefaultDeclaration: {
+        exit(path) {
+          const { node } = path;
+          if (t.isFunctionDeclaration(node.declaration)) {
+            const { id, params, returnType, body } = node.declaration;
+            if (params.length === 1) {
+              const [param] = params;
 
-            if (
-              (t.isIdentifier(id) &&
-                t.isTSTypeAnnotation(param.typeAnnotation) &&
-                t.isTSTypeReference(param.typeAnnotation.typeAnnotation) &&
-                t.isIdentifier(param.typeAnnotation.typeAnnotation.typeName) &&
-                param.typeAnnotation.typeAnnotation.typeName.name.endsWith(
-                  "Props"
-                )) ||
-              (t.isIdentifier(id) &&
-                t.isTSTypeAnnotation(param.typeAnnotation) &&
-                t.isTSTypeAnnotation(returnType) &&
-                t.isTSTypeReference(returnType.typeAnnotation) &&
-                t.isTSQualifiedName(returnType.typeAnnotation.typeName) &&
-                t.isIdentifier(returnType.typeAnnotation.typeName.left, {
-                  name: "React",
-                }) &&
-                t.isIdentifier(returnType.typeAnnotation.typeName.right) &&
-                ["ReactNode", "ReactElement"].includes(
-                  returnType.typeAnnotation.typeName.right.name
-                ))
-            ) {
-              const fn = t.functionExpression(null, params, body);
+              if (
+                (t.isIdentifier(id) &&
+                  t.isTSTypeAnnotation(param.typeAnnotation) &&
+                  t.isTSTypeReference(param.typeAnnotation.typeAnnotation) &&
+                  t.isIdentifier(
+                    param.typeAnnotation.typeAnnotation.typeName
+                  ) &&
+                  param.typeAnnotation.typeAnnotation.typeName.name.endsWith(
+                    "Props"
+                  )) ||
+                (t.isIdentifier(id) &&
+                  t.isTSTypeAnnotation(param.typeAnnotation) &&
+                  t.isTSTypeAnnotation(returnType) &&
+                  t.isTSTypeReference(returnType.typeAnnotation) &&
+                  t.isTSQualifiedName(returnType.typeAnnotation.typeName) &&
+                  t.isIdentifier(returnType.typeAnnotation.typeName.left, {
+                    name: "React",
+                  }) &&
+                  t.isIdentifier(returnType.typeAnnotation.typeName.right) &&
+                  ["ReactNode", "ReactElement"].includes(
+                    returnType.typeAnnotation.typeName.right.name
+                  ))
+              ) {
+                const fn = t.functionExpression(null, params, body);
 
-              // We always include a return type so that the output code conforms to
-              // https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/2201682700/TypeScript+Best+Practices#Functions-should-have-return-types
-              fn.returnType = createReturnType();
+                // We always include a return type so that the output code conforms to
+                // https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/2201682700/TypeScript+Best+Practices#Functions-should-have-return-types
+                fn.returnType = createReturnType();
 
-              replaceWith(
-                path,
-                t.variableDeclaration("const", [t.variableDeclarator(id, fn)]),
-                state.config.filePath,
-                reporter
-              );
+                const newNodes = [
+                  t.variableDeclaration("const", [
+                    t.variableDeclarator(id, fn),
+                  ]),
+                  t.exportDefaultDeclaration(t.identifier(id.name)),
+                ];
 
-              delete param.typeAnnotation;
+                replaceWithMultiple(
+                  path,
+                  newNodes,
+                  globalState.config.filePath,
+                  reporter
+                );
+              }
             }
           }
-        }
+        },
       },
     },
-    ExportDefaultDeclaration: {
-      exit(path) {
-        const { node } = path;
-        if (t.isFunctionDeclaration(node.declaration)) {
-          const { id, params, returnType, body } = node.declaration;
-          if (params.length === 1) {
-            const [param] = params;
-
-            if (
-              (t.isIdentifier(id) &&
-                t.isTSTypeAnnotation(param.typeAnnotation) &&
-                t.isTSTypeReference(param.typeAnnotation.typeAnnotation) &&
-                t.isIdentifier(param.typeAnnotation.typeAnnotation.typeName) &&
-                param.typeAnnotation.typeAnnotation.typeName.name.endsWith(
-                  "Props"
-                )) ||
-              (t.isIdentifier(id) &&
-                t.isTSTypeAnnotation(param.typeAnnotation) &&
-                t.isTSTypeAnnotation(returnType) &&
-                t.isTSTypeReference(returnType.typeAnnotation) &&
-                t.isTSQualifiedName(returnType.typeAnnotation.typeName) &&
-                t.isIdentifier(returnType.typeAnnotation.typeName.left, {
-                  name: "React",
-                }) &&
-                t.isIdentifier(returnType.typeAnnotation.typeName.right) &&
-                ["ReactNode", "ReactElement"].includes(
-                  returnType.typeAnnotation.typeName.right.name
-                ))
-            ) {
-              const fn = t.functionExpression(null, params, body);
-
-              // We always include a return type so that the output code conforms to
-              // https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/2201682700/TypeScript+Best+Practices#Functions-should-have-return-types
-              fn.returnType = createReturnType();
-
-              const newNodes = [
-                t.variableDeclaration("const", [t.variableDeclarator(id, fn)]),
-                t.exportDefaultDeclaration(t.identifier(id.name)),
-              ];
-
-              replaceWithMultiple(
-                path,
-                newNodes,
-                state.config.filePath,
-                reporter
-              );
-
-              delete param.typeAnnotation;
-            }
-          }
-        }
-      },
-    },
-  });
+    undefined,
+    initialState
+  );
 
   return Promise.all(awaitPromises);
 }

--- a/src/convert/jsx-spread/jsx-spread.test.ts
+++ b/src/convert/jsx-spread/jsx-spread.test.ts
@@ -296,7 +296,7 @@ describe("transform spread JSX attributes", () => {
       foo: number
     };
 
-    const Foobar = function(x): React.ReactElement { 
+    const Foobar = function(x: Props): React.ReactElement { 
       const { it, ...rest } = x;
       const El = Mine;
       return <El it={it} {...rest} />

--- a/src/convert/private-types.test.ts
+++ b/src/convert/private-types.test.ts
@@ -17,7 +17,7 @@ describe("transform type annotations", () => {
 
   it("converts React$Element", async () => {
     const src = `const Component = (props: Props): React$Element => {return <div />};`;
-    const expected = `const Component = (props): React.ReactElement => {return <div />};`;
+    const expected = `const Component = (props: Props): React.ReactElement => {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -29,7 +29,7 @@ describe("transform type annotations", () => {
 
   it("converts Flow namespaces", async () => {
     const src = `const Component = (props: Props): Any$Thing => {return <div />};`;
-    const expected = `const Component = (props): React.ReactElement => {return <div />};`;
+    const expected = `const Component = (props: Props): React.ReactElement => {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -40,7 +40,7 @@ describe("transform type annotations", () => {
       },
     });
     const src = `const Component = (props: Props): Any$Thing => {return <div />};`;
-    const expected = `const Component = (props): React.ReactElement => {return <div />};`;
+    const expected = `const Component = (props: Props): React.ReactElement => {return <div />};`;
     expect(await transform(src, state)).toBe(expected);
   });
 

--- a/src/convert/type-annotations.test.ts
+++ b/src/convert/type-annotations.test.ts
@@ -369,7 +369,7 @@ describe("transform type annotations", () => {
 
   it("Converts React.Node to React.ReactElement in function return", async () => {
     const src = `const Component = (props: Props): React.Node => {return <div />};`;
-    const expected = `const Component = (props): React.ReactElement => {return <div />};`;
+    const expected = `const Component = (props: Props): React.ReactElement => {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -415,9 +415,7 @@ describe("transform type annotations", () => {
     ) => {
       return <Test {...props} globals={globals} />;
     };`;
-    const expected = dedent`const Test = (
-      props: Props & DefaultProps,
-    ) => {
+    const expected = dedent`const Test = (props: Props & DefaultProps) => {
       return <Test {...props} globals={globals} />;
     };`;
     expect(await transform(src)).toBe(expected);
@@ -455,7 +453,7 @@ describe("transform type annotations", () => {
 
   it("Converts React.Node to React.ReactElement in arrow function", async () => {
     const src = `const Component = (props: Props): React.Node => {return <div />};`;
-    const expected = `const Component = (props): React.ReactElement => {return <div />};`;
+    const expected = `const Component = (props: Props): React.ReactElement => {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -464,7 +462,7 @@ describe("transform type annotations", () => {
       if (foo) return (<div />);
       return null;
     };`;
-    const expected = dedent`const Component = (props): React.ReactElement => {
+    const expected = dedent`const Component = (props: Props): React.ReactElement => {
       if (foo) return (<div />);
       return null;
     };`;
@@ -473,7 +471,7 @@ describe("transform type annotations", () => {
 
   it("Converts React.Node to React.ReactElement in normal function", async () => {
     const src = `function Component(props: Props): React.Node {return <div />};`;
-    const expected = `const Component = function(props): React.ReactElement {return <div />};`;
+    const expected = `const Component = function(props: Props): React.ReactElement {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -482,7 +480,7 @@ describe("transform type annotations", () => {
       if (foo) return (<div />);
       return null;
     };`;
-    const expected = dedent`const Component = function(props): React.ReactElement {
+    const expected = dedent`const Component = function(props: Props): React.ReactElement {
       if (foo) return (<div />);
       return null;
     };`;


### PR DESCRIPTION
## Summary:
The codemod was adding React.ReactElement as a return type to functions that take "props" as a param, but aren't functions (e.g. mapPropsToState, mapPropsToDispatch, etc.).  This PR fixes that issue.  It also, removes the code that was stripping the type annotation from the "props" param in functional components.  I forgot to remove this code in #7.

Issue: FEI-5075

## Test plan:
- yarn test