### PR TITLE
FEI-5094: Add ability to specify override files

### DIFF
--- a/src/runner/migration-reporter/migration-reporter.ts
+++ b/src/runner/migration-reporter/migration-reporter.ts
@@ -28,6 +28,7 @@ enum MigrationReportItemType {
   flowFailToParse = "flowFailToParse",
   foundNonFlowFile = "foundNonFlowFile",
   foundDeclarationFile = "foundDeclarationFile",
+  foundOverrideFile = "foundOverrideFile",
   usedJSXSpread = "usedJSXSpread",
   unsupportedComponentProp = "unsupportedComponentProp",
   maybeNeedTypes = "maybeNeedTypes",
@@ -364,6 +365,16 @@ class MigrationReporter {
       filePath,
       { start: { column: 0, line: 0 }, end: { column: 0, line: 0 } },
       "The codemod skipped this file because it contains Flow type declarations. Declarations are ignored since they often have issues parsing or conflict with TS declarations."
+    );
+  }
+
+  foundOverrideFile(filePath: string) {
+    this.log(
+      MigrationReportItemType.foundOverrideFile,
+      MigrationReportItemSeverity.info,
+      filePath,
+      { start: { column: 0, line: 0 }, end: { column: 0, line: 0 } },
+      "The codemod skipped this file because it has an override file which will be used instead."
     );
   }
 

--- a/src/runner/process-batch.ts
+++ b/src/runner/process-batch.ts
@@ -44,6 +44,21 @@ export async function processBatchAsync(
         ) {
           return;
         }
+
+        // Checks if a .ts override file exists and stops early
+        // if there is one.
+        if (fs.existsSync(filePath.replace(/\.jsx?$/, ".ts"))) {
+          reporter.foundDeclarationFile(filePath);
+          return;
+        }
+
+        // Checks if a .tsx override file exists and stops early
+        // if there is one.
+        if (fs.existsSync(filePath.replace(/\.jsx?$/, ".tsx"))) {
+          reporter.foundDeclarationFile(filePath);
+          return;
+        }
+
         const fileBuffer = await fs.readFile(filePath);
 
         const fileText = fileBuffer.toString("utf8");


### PR DESCRIPTION
## Summary:
We'd like to be able to provide .ts/.tsx override files for Flow files that prove troublesome to convert automatically.  We already use the same capability in reverse with flowgen and those existing repos we've converted where we need to generate Flow types from .d.ts files.  Given the amount of files in webapp/services/static, there will likely be files that are hard for the codemod to convert and we don't want to have to do a bunch of many fixes after running the codemod.  Instead, we'd like to do the manual fixes beforehand.  That's where this feature will come in handy.

Issue: FEI-5094

## Test plan:
- create some .js(x) Flow files and some .ts(x) TypeScript files beside them in a separate directory as well as some .js(x) files without a corresponding .ts(x) file
- make sure the contents of the .ts(x) files is different from the .js(x) Flow files
- run the codemod using 'yarn typescriptify convert --dropImportExtensions --path ../codemod-test --write --delete'
- see that the codemod printed out info logs about the override files
- see that the override files were left unchanged
- see that the .js(x) files without overrides were converted by the codemod

```
kevinbarabash@Kevins-MacBook-Pro flow-to-typescript-codemod % yarn typescriptify convert --dropImportExtensions --path ../codemod-test --write --delete                     
yarn run v1.22.19
$ yarn build && node ./dist/index.js convert --dropImportExtensions --path ../codemod-test --write --delete
$ ./esBuild.js

Stripe Flow to TypeScript Codemod

●  note      Selecting a batch size of 1.
●  note      Spawning 3 workers to process 3 files.
☒  complete  Finished processing batches - [3/3]
ℹ  info      Deleting all the Flow files.
●  note      Merging reports from 3 workers.

Migration Report

foundDeclarationFile
⚠  warning   The codemod skipped this file because it contains Flow type declarations. Declarations are ignored since they often have issues parsing or conflict with TS declarations. (../codemod-test/bar.js:0:0)
⚠  warning   The codemod skipped this file because it contains Flow type declarations. Declarations are ignored since they often have issues parsing or conflict with TS declarations. (../codemod-test/baz.jsx:0:0)


☒  complete  Found 0 logs, 2 warnings, and 0 errors.
✔  success   Converted 3 lines in 3 files.
✨  Done in 3.58s.
```

```
kevinbarabash@Kevins-MacBook-Pro codemod-test % ls
bar.ts	baz.tsx	foo.ts
kevinbarabash@Kevins-MacBook-Pro codemod-test % cat baz.tsx 
export const baz: boolean = false;  // in baz.js the boolean was `true`
kevinbarabash@Kevins-MacBook-Pro codemod-test % cat bar.ts 
export const bar: string = "world"; // in bar.js the string was "hello"
kevinbarabash@Kevins-MacBook-Pro codemod-test % cat foo.ts 
export const foo: number = 123;
kevinbarabash@Kevins-MacBook-Pro codemod-test % 
```