### PR TITLE
FEI-5010: Remove Flow suppression comments attached to JSXAttributes

### DIFF
--- a/src/convert/remove-flow-comments.test.ts
+++ b/src/convert/remove-flow-comments.test.ts
@@ -86,6 +86,7 @@ describe("remove-flow-pragmas", () => {
   it("should remove suppressions", async () => {
     const src = dedent`
         // $FlowFixMe
+        // $FlowFixMe[incompatible-type]: with a comment
         // $FlowIssue
         // $FlowExpectedError
         // $FlowIgnore
@@ -99,6 +100,28 @@ describe("remove-flow-pragmas", () => {
     `;
 
     expect(await transform(src)).toEqual(expected);
+  });
+
+  it("should remove suppressions inside JSX blocks", async () => {
+    const src = dedent`
+      const myButton = <button
+        // $FlowFixMe
+        // $FlowFixMe[incompatible-type]: with a comment
+        // $FlowIssue
+        // $FlowExpectedError
+        // $FlowIgnore
+        ref={(node) => (this.node = node)}
+      >
+        Click me!
+      </button>;`;
+
+    expect(await transform(src)).toMatchInlineSnapshot(`
+      "const myButton = <button
+        ref={(node) => (this.node = node)}
+      >
+        Click me!
+      </button>;"
+    `);
   });
 
   it("should leave non suppressions", async () => {

--- a/src/convert/remove-flow-comments.ts
+++ b/src/convert/remove-flow-comments.ts
@@ -11,6 +11,53 @@ const flowComments = [
   "$FlowIgnore",
 ];
 
+type CommentKind =
+  | types.namedTypes.Block
+  | types.namedTypes.Line
+  | types.namedTypes.CommentBlock
+  | types.namedTypes.CommentLine;
+
+const filterMapCommentKinds = (comments: CommentKind[] | null | undefined) => {
+  return (
+    comments
+      ?.filter(
+        (comment) => !flowComments.some((c) => comment.value.includes(c))
+      )
+      .map((comment) => {
+        if (comment.value.includes("@noflow")) {
+          return {
+            ...comment,
+            value: comment.value.replace(/@noflow/, "@ts-nocheck"),
+          };
+        }
+
+        return comment;
+      }) || comments
+  );
+};
+
+const filterMapComments = (
+  comments: readonly types.namedTypes.Comment[] | null
+) => {
+  comments; // ?
+  return (
+    comments
+      ?.filter(
+        (comment) => !flowComments.some((c) => comment.value.includes(c))
+      )
+      .map((comment) => {
+        if (comment.value.includes("@noflow")) {
+          return {
+            ...comment,
+            value: comment.value.replace(/@noflow/, "@ts-nocheck"),
+          };
+        }
+
+        return comment;
+      }) || comments
+  );
+};
+
 /**
  * Scan through top level programs, or code blocks and remove Flow-specific comments
  */
@@ -24,23 +71,7 @@ const removeComments = (
   const nodes: Array<types.namedTypes.Node> = path.node.body;
 
   for (const rootNode of nodes) {
-    const { comments } = rootNode;
-
-    rootNode.comments =
-      comments
-        ?.filter(
-          (comment) => !flowComments.some((c) => comment.value.includes(c))
-        )
-        .map((comment) => {
-          if (comment.value.includes("@noflow")) {
-            return {
-              ...comment,
-              value: comment.value.replace(/@noflow/, "@ts-nocheck"),
-            };
-          }
-
-          return comment;
-        }) || rootNode.comments;
+    rootNode.comments = filterMapCommentKinds(rootNode.comments);
   }
 };
 
@@ -54,6 +85,10 @@ export function removeFlowComments({ file }: TransformerInput) {
     },
     BlockStatement(path) {
       removeComments(path);
+    },
+    JSXAttribute({ node }) {
+      // @ts-expect-error: comments is readonly
+      node.comments = filterMapComments(node.comments);
     },
   });
 }

--- a/src/convert/remove-flow-comments.ts
+++ b/src/convert/remove-flow-comments.ts
@@ -39,7 +39,6 @@ const filterMapCommentKinds = (comments: CommentKind[] | null | undefined) => {
 const filterMapComments = (
   comments: readonly types.namedTypes.Comment[] | null
 ) => {
-  comments; // ?
   return (
     comments
       ?.filter(


### PR DESCRIPTION
## Summary:
I had to clean up Flow suppression comments manual after migrating wonder-blocks and perseus.  It seems that the codemod already wasn't removing comments attached to JSXAttribute nodes.  This PR updates it to handle those.

Issue: FEI-5010

## Test plan:
- yarn test