### PR TITLE
FEI-5072: Always return React.ReactNode from render() methods

### DIFF
--- a/src/convert/declarations.test.ts
+++ b/src/convert/declarations.test.ts
@@ -524,7 +524,17 @@ describe("transform declarations", () => {
       render(): React.Node {return <div />};
     };`;
     const expected = dedent`class Foo extends React.Component {
-      render(): React.ReactElement {return <div />};
+      render(): React.ReactNode {return <div />};
+    };`;
+    expect(await transform(src)).toBe(expected);
+  });
+
+  it("Converts React.Element<'div'> to React.ReactElement in render", async () => {
+    const src = dedent`class Foo extends React.Component {
+      render(): React.Element<"div"> {return <div />};
+    };`;
+    const expected = dedent`class Foo extends React.Component {
+      render(): React.ReactNode {return <div />};
     };`;
     expect(await transform(src)).toBe(expected);
   });
@@ -537,7 +547,7 @@ describe("transform declarations", () => {
       };
     };`;
     const expected = dedent`class Foo extends React.Component {
-      render(): React.ReactElement | null {
+      render(): React.ReactNode | null {
         if (foo) return (<div />);
         return null;
       };
@@ -550,7 +560,7 @@ describe("transform declarations", () => {
       render = (): React.Node => {return <div />};
     };`;
     const expected = dedent`class Foo extends React.Component {
-      render = (): React.ReactElement => {return <div />};
+      render = (): React.ReactNode => {return <div />};
     };`;
     expect(await transform(src)).toBe(expected);
   });


### PR DESCRIPTION
## Summary:
We have a bunch of code where the `render()` methods' return type is set to `React.Element<"div">` or something like that.  This was the result of a codemod that inserted inferred types.  We'd like our code to be more consistent moving forward so if we find a `render()` method with a return type like this we convert it to `React.ReactNode`.

Issue: FEI-5072

## Test plan:
- yarn test