### PR TITLE
FEI-5135: tweak the renamining of storybook stories

### DIFF
--- a/src/runner/process-batch.ts
+++ b/src/runner/process-batch.ts
@@ -129,10 +129,8 @@ export async function processBatchAsync(
 
         const tsFilePath = targetFilePath
           .replace(/(__[^_]+__\/)?(.*)_([^\.]+)\.(jsx?)$/, "$1$2.$3.$4")
-          .replace(
-            /\.jsx?$/,
-            state.hasJsx || options.forceTSX ? ".tsx" : ".ts"
-          );
+          .replace(/\.jsx?$/, state.hasJsx || options.forceTSX ? ".tsx" : ".ts")
+          .replace(/\.jsx?\.stories\./, ".stories.");
 
         if (isTestFile) {
           const fileName = path.basename(filePath);


### PR DESCRIPTION
## Summary:
We want our stories filenames to be consistent across repos.  There's no longer a reason for 

Issue: FEI-5135

## Test plan:
- create a test repo with various .js(x) files in various directories including foo.js.stories.jsx in a __stories__ subdirectory
- run the codemod
- see that foo.js.stories.jsx is now foo.stories.ts
- in webapp, rename hero.jsx.stories.jsx, see that the static-service/require-stories lint rule doesn't complain