### PR TITLE
Improve file renaming logic + add tests

### DIFF
--- a/src/runner/process-batch.test.ts
+++ b/src/runner/process-batch.test.ts
@@ -1,0 +1,19 @@
+import { renameFilePath } from "./process-batch";
+
+describe("renameFilePath", () => {
+  it.each`
+    inPath                           | jsx      | outPath
+    ${"./src/foo_bar.js"}            | ${false} | ${"./src/foo_bar.ts"}
+    ${"./src/foo_test.js"}           | ${false} | ${"./src/foo.test.ts"}
+    ${"./src/foo.jsx.stories.js"}    | ${false} | ${"./src/foo.stories.ts"}
+    ${"./src/foo.jsx.stories.js"}    | ${true}  | ${"./src/foo.stories.tsx"}
+    ${"./src/__tests__/foo_bar.js"}  | ${false} | ${"./src/__tests__/foo_bar.ts"}
+    ${"./src/__tests__/foo_test.js"} | ${false} | ${"./src/__tests__/foo.test.ts"}
+    ${"./src/__tests__/foo_test.js"} | ${true}  | ${"./src/__tests__/foo.test.tsx"}
+    ${"./src/foo_testdata.js"}       | ${false} | ${"./src/foo.testdata.ts"}
+    ${"./src/foo_flowtest.js"}       | ${false} | ${"./src/foo.typestest.ts"}
+    ${"./src/foo_types.js"}          | ${false} | ${"./src/foo.types.ts"}
+  `("inPath: $inPath, jsx: ${jsx} -> $outPath", ({ inPath, jsx, outPath }) => {
+    expect(renameFilePath(inPath, jsx)).toEqual(outPath);
+  });
+});

--- a/src/runner/process-batch.ts
+++ b/src/runner/process-batch.ts
@@ -26,6 +26,19 @@ export const recastOptions: Options = {
   objectCurlySpacing: false,
 };
 
+export const renameFilePath = (
+  targetFilePath: string,
+  jsx: boolean
+): string => {
+  const tsFilePath = targetFilePath
+    .replace(/_(test|testdata|flowtest|types)\.(jsx?)$/, ".$1.$2")
+    .replace(".flowtest.", ".typestest.")
+    .replace(/\.jsx?\.stories\./, ".stories.")
+    .replace(/\.jsx?$/, jsx ? ".tsx" : ".ts");
+
+  return tsFilePath;
+};
+
 /**
  * Process a batch of files, running transforms and renaming files
  */
@@ -127,10 +140,10 @@ export async function processBatchAsync(
                 path.normalize(options.target)
               );
 
-        const tsFilePath = targetFilePath
-          .replace(/(__[^_]+__\/)?(.*)_([^\.]+)\.(jsx?)$/, "$1$2.$3.$4")
-          .replace(/\.jsx?$/, state.hasJsx || options.forceTSX ? ".tsx" : ".ts")
-          .replace(/\.jsx?\.stories\./, ".stories.");
+        const tsFilePath = renameFilePath(
+          targetFilePath,
+          state.hasJsx || options.forceTSX
+        );
 
         if (isTestFile) {
           const fileName = path.basename(filePath);


### PR DESCRIPTION
## Summary:
We're still seeing some situations where files are being renamed incorrectly when they shouldn't when migrating the mobile app.  This PR attempts to fix the issue and adds some tests to verify the fix.

Issue: None

## Test plan:
- yarn test process-batch