### PR TITLE
FEI-5141: Convert .filter(Boolean) to .filter(isTruthy)

### DIFF
--- a/src/convert/add-imports.ts
+++ b/src/convert/add-imports.ts
@@ -11,12 +11,29 @@ export function addImports({ state, file }: TransformerInput) {
   traverse(file, {
     Program: {
       exit(path) {
+        const newImportDecls = [];
         if (state.usedUtils) {
           const importDeclaration = t.importDeclaration(
             [t.importSpecifier(t.identifier("Flow"), t.identifier("Flow"))],
             t.stringLiteral("flow-to-typescript-codemod")
           );
-          path.node.body = [importDeclaration, ...path.node.body];
+          newImportDecls.push(importDeclaration);
+        }
+        if (state.usedIsTruthy) {
+          const importDeclaration = t.importDeclaration(
+            [
+              t.importSpecifier(
+                t.identifier("isTruthy"),
+                t.identifier("isTruthy")
+              ),
+            ],
+            t.stringLiteral("@khanacademy/wonder-stuff-core")
+          );
+          newImportDecls.push(importDeclaration);
+        }
+
+        if (newImportDecls.length > 0) {
+          path.node.body = [...newImportDecls, ...path.node.body];
         }
       },
     },

--- a/src/convert/default-transformer-chain.ts
+++ b/src/convert/default-transformer-chain.ts
@@ -10,6 +10,7 @@ import {
   typeAnnotationTransformRunner,
   removeFlowCommentTransformRunner,
   functionalComponentTransformerRunner,
+  filterBooleanTranforRunner,
 } from "./transform-runners";
 import { Transformer } from "./transformer";
 
@@ -25,7 +26,11 @@ export const defaultTransformerChain: readonly Transformer[] = [
   typeAnnotationTransformRunner,
   patternTransformRunner,
   jsxSpreadTransformRunner,
-  importTransformRunner,
   removeFlowCommentTransformRunner,
   functionalComponentTransformerRunner,
+  filterBooleanTranforRunner,
+
+  // This transform must go last since it looks at `state` which can
+  // be modified by any other transformer.
+  importTransformRunner,
 ];

--- a/src/convert/migrate/filter-boolean.test.ts
+++ b/src/convert/migrate/filter-boolean.test.ts
@@ -1,0 +1,40 @@
+import {
+  stateBuilder,
+  transform,
+  MockedMigrationReporter,
+} from "../utils/testing";
+
+jest.mock("../../runner/migration-reporter/migration-reporter.ts");
+
+afterEach(MockedMigrationReporter.mockReset);
+
+describe(".filter(Boolean) -> .filter(isTruthy)", () => {
+  it("should handle a single .filter(Boolean)", async () => {
+    const src = `let result = array.filter(Boolean);`;
+
+    expect(await transform(src)).toMatchInlineSnapshot(`
+      "import {isTruthy} from '@khanacademy/wonder-stuff-core';
+      let result = array.filter(isTruthy);"
+    `);
+  });
+
+  it("should handle a multiple .filter(Boolean)s", async () => {
+    const src = `let result = array.filter(Boolean).filter(Boolean);`;
+
+    expect(await transform(src)).toMatchInlineSnapshot(`
+      "import {isTruthy} from '@khanacademy/wonder-stuff-core';
+      let result = array.filter(isTruthy).filter(isTruthy);"
+    `);
+  });
+
+  it("should handle inserting multiple imports", async () => {
+    const src = `let result = array.filter(Boolean);`;
+
+    expect(await transform(src, stateBuilder({ usedUtils: true })))
+      .toMatchInlineSnapshot(`
+      "import {Flow} from 'flow-to-typescript-codemod';
+      import {isTruthy} from '@khanacademy/wonder-stuff-core';
+      let result = array.filter(isTruthy);"
+    `);
+  });
+});

--- a/src/convert/migrate/filter-boolean.ts
+++ b/src/convert/migrate/filter-boolean.ts
@@ -1,0 +1,30 @@
+import * as t from "@babel/types";
+import traverse from "@babel/traverse";
+import { TransformerInput } from "../transformer";
+
+/**
+ * Converts .filter(Boolean) to .filter(isTruthy)
+ *
+ * This is necessary because `.filter(Boolean)` in TS doesn't behave the same
+ * way it does in Flow.  The replacement, `isTruthy`, is a predicate type which
+ * does behave the same way.  Unfortunately, this solution only works in TS which
+ * is why we're having the codemod make this change instead of doing it ourselves
+ * pre-emptively.
+ */
+export function transformFilterBoolean({ state, file }: TransformerInput) {
+  traverse(file, {
+    CallExpression(path) {
+      const { node } = path;
+      const { callee, arguments: args } = node;
+      if (
+        t.isMemberExpression(callee) &&
+        t.isIdentifier(callee.property, { name: "filter" }) &&
+        t.isIdentifier(args[0], { name: "Boolean" })
+      ) {
+        args[0] = t.identifier("isTruthy");
+        // This value is conusmed in add-imports.ts.
+        state.usedIsTruthy = true;
+      }
+    },
+  });
+}

--- a/src/convert/migrate/type.test.ts
+++ b/src/convert/migrate/type.test.ts
@@ -1,0 +1,11 @@
+import { transform } from "../utils/testing";
+
+describe("transform type annotations", () => {
+  it("$Values<T>", async () => {
+    const src = `type Values = $Values<typeof T>`;
+
+    expect(await transform(src)).toMatchInlineSnapshot(
+      `"type Values = typeof T[keyof typeof T];"`
+    );
+  });
+});

--- a/src/convert/transform-runners.ts
+++ b/src/convert/transform-runners.ts
@@ -12,6 +12,7 @@ import { transformTypeAnnotations } from "./type-annotations";
 import { removeFlowComments } from "./remove-flow-comments";
 import { annotateNoFlow } from "./annotate-no-flow";
 import { transformFunctionalComponents } from "./functional-components";
+import { transformFilterBoolean } from "./migrate/filter-boolean";
 
 const standardTransformRunnerFactory = (transformer: Transformer) => {
   return (transformerInput: TransformerInput) => {
@@ -66,3 +67,6 @@ export const functionalComponentTransformerRunner: Transformer = async (
 ) => {
   await transformFunctionalComponents(transformerInput);
 };
+
+export const filterBooleanTranforRunner: Transformer =
+  standardTransformRunnerFactory(transformFilterBoolean);

--- a/src/convert/utils/testing.ts
+++ b/src/convert/utils/testing.ts
@@ -123,6 +123,7 @@ const stateBuilder = (
   return {
     hasJsx: false,
     usedUtils: false,
+    usedIsTruthy: false,
     ...stateOverrides,
     config: {
       filePath,

--- a/src/runner/process-batch.ts
+++ b/src/runner/process-batch.ts
@@ -95,6 +95,7 @@ export async function processBatchAsync(
         const state: State = {
           hasJsx: false,
           usedUtils: false,
+          usedIsTruthy: false,
           config: {
             filePath,
             isTestFile,

--- a/src/runner/state.ts
+++ b/src/runner/state.ts
@@ -7,6 +7,10 @@ export type State = {
   // Set this flag if utility types were encountered, and an import should be added
   usedUtils: boolean;
 
+  // Set this flag if `isTruthy` predicate type needs to be imported from
+  // @khanacademy/wonder-stuff-core.
+  usedIsTruthy: boolean;
+
   // Config is used to store immutable configuration
   readonly config: {
     // The path of the current file that is being converted


### PR DESCRIPTION
## Summary:
.filter(Boolean) doesn't work in TS the same way it does in Flow so we need to migrate to .filter(isTruthy) where 'isTruthy' is a type predicate.  I thought that this would also work in Flow, but it doesn't which is why we need to update the codemod to make to the conversion for us.  There are about 100 files in webapp where this transform will be applied.

Issue: FEI-5141

## Test plan:
- yarn test