### PR TITLE
FEI-5154: Wrap object literals being returned from arrow functions in parens

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,16 +26,16 @@
     "types": "tsc -b ."
   },
   "resolutions": {
-    "@babel/parser": "7.19.0",
-    "@babel/traverse": "7.19.0",
-    "@babel/types": "7.19.0",
+    "@babel/parser": "7.16.0",
+    "@babel/traverse": "7.16.0",
+    "@babel/types": "7.16.0",
     "code-block-writer": "10",
     "minimist": "1.2.6"
   },
   "devDependencies": {
-    "@babel/parser": "7.19.0",
-    "@babel/traverse": "7.19.0",
-    "@babel/types": "7.19.0",
+    "@babel/parser": "7.16.0",
+    "@babel/traverse": "7.16.0",
+    "@babel/types": "7.16.0",
     "@types/babel__traverse": "^7.0.7",
     "@types/csv-stringify": "^3.1.0",
     "@types/dedent": "^0.7.0",

--- a/src/convert/function-visitor.ts
+++ b/src/convert/function-visitor.ts
@@ -209,11 +209,22 @@ export const functionVisitor = <
       }
     }
 
+    path.node.extra; // ?
+
     // let us fix return types for functions that return objects
     if (
       (t.isObjectExpression(path.node.body) &&
         (path.node.returnType || path.node.typeParameters)) ||
       (path.node.extra?.parenthesized && t.isExpression(path.node.body))
+    ) {
+      path.node.extra = { ...path.node.extra, parenthesized: false };
+      path.node.body = t.parenthesizedExpression(path.node.body);
+    }
+
+    // let us fix return types for functions that return objects
+    if (
+      t.isObjectExpression(path.node.body) &&
+      t.isExpression(path.node.body)
     ) {
       path.node.extra = { ...path.node.extra, parenthesized: false };
       path.node.body = t.parenthesizedExpression(path.node.body);

--- a/src/convert/function-visitor.ts
+++ b/src/convert/function-visitor.ts
@@ -209,8 +209,6 @@ export const functionVisitor = <
       }
     }
 
-    path.node.extra; // ?
-
     // let us fix return types for functions that return objects
     if (
       (t.isObjectExpression(path.node.body) &&

--- a/src/convert/migrate/type.test.ts
+++ b/src/convert/migrate/type.test.ts
@@ -36,7 +36,9 @@ describe("transform type annotations", () => {
   it("handles returning object literals from arrow functions (simple)", async () => {
     const src = `const foo = (x, y) => ({x, y})`;
 
-    expect(await transform(src)).toMatchInlineSnapshot();
+    expect(await transform(src)).toMatchInlineSnapshot(
+      `"const foo = (x, y) => ({x, y})"`
+    );
   });
 
   it("handles returning object literals from arrow functions (complex)", async () => {

--- a/src/convert/migrate/type.test.ts
+++ b/src/convert/migrate/type.test.ts
@@ -32,4 +32,28 @@ describe("transform type annotations", () => {
       `"function foo(x: number, y: string): boolean { return true; }"`
     );
   });
+
+  it("handles returning object literals from arrow functions", async () => {
+    const src = `export const ErrorBoundary4: unknown = fixture(
+      "with ErrorBoundary and custom handler (see console)",
+      ({log}) => ({
+          children: <BadComponent />,
+          onError: (error) => {
+              log("Handled an error.", error);
+          },
+      }),
+  );`;
+
+    expect(await transform(src)).toMatchInlineSnapshot(`
+      "export const ErrorBoundary4: unknown = fixture(
+            \\"with ErrorBoundary and custom handler (see console)\\",
+            ({log}) => ({
+                children: <BadComponent />,
+                onError: (error) => {
+                    log(\\"Handled an error.\\", error);
+                },
+            }),
+        );"
+    `);
+  });
 });

--- a/src/convert/migrate/type.test.ts
+++ b/src/convert/migrate/type.test.ts
@@ -33,7 +33,13 @@ describe("transform type annotations", () => {
     );
   });
 
-  it("handles returning object literals from arrow functions", async () => {
+  it("handles returning object literals from arrow functions (simple)", async () => {
+    const src = `const foo = (x, y) => ({x, y})`;
+
+    expect(await transform(src)).toMatchInlineSnapshot();
+  });
+
+  it("handles returning object literals from arrow functions (complex)", async () => {
     const src = `export const ErrorBoundary4: unknown = fixture(
       "with ErrorBoundary and custom handler (see console)",
       ({log}) => ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,7 +16,7 @@
   dependencies:
     "@babel/highlight" "^7.14.5"
 
-"@babel/code-frame@^7.18.6":
+"@babel/code-frame@^7.16.0", "@babel/code-frame@^7.18.6":
   version "7.21.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.21.4.tgz#d0fa9e4413aca81f2b23b9442797bda1826edb39"
   integrity sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==
@@ -58,7 +58,7 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.19.0":
+"@babel/generator@^7.16.0":
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.21.5.tgz#c0c0e5449504c7b7de8236d99338c3e2a340745f"
   integrity sha512-SrKK/sRv8GesIW1bDagf9cCG38IOMYZusoe1dfg0D8aiUe3Amvoj1QtjTPAWcfrZFvIwlleLb0gxzQidL9w14w==
@@ -78,12 +78,7 @@
     browserslist "^4.16.6"
     semver "^6.3.0"
 
-"@babel/helper-environment-visitor@^7.18.9":
-  version "7.21.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.21.5.tgz#c769afefd41d171836f7cb63e295bedf689d48ba"
-  integrity sha512-IYl4gZ3ETsWocUWgsFZLM5i1BYx9SoemminVEXadgLBa9TdeorzgLKm8wWLA6J1N/kT3Kch8XIk1laNzYoHKvQ==
-
-"@babel/helper-function-name@^7.19.0":
+"@babel/helper-function-name@^7.16.0":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz#d552829b10ea9f120969304023cd0645fa00b1b4"
   integrity sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==
@@ -91,7 +86,7 @@
     "@babel/template" "^7.20.7"
     "@babel/types" "^7.21.0"
 
-"@babel/helper-hoist-variables@^7.18.6":
+"@babel/helper-hoist-variables@^7.16.0":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz#d4d2c8fb4baeaa5c68b99cc8245c56554f926678"
   integrity sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==
@@ -162,24 +157,19 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
-"@babel/helper-split-export-declaration@^7.18.6":
+"@babel/helper-split-export-declaration@^7.16.0":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz#7367949bc75b20c6d5a5d4a97bba2824ae8ef075"
   integrity sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==
   dependencies:
     "@babel/types" "^7.18.6"
 
-"@babel/helper-string-parser@^7.18.10":
-  version "7.21.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.21.5.tgz#2b3eea65443c6bdc31c22d037c65f6d323b6b2bd"
-  integrity sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==
-
 "@babel/helper-validator-identifier@^7.14.5":
   version "7.14.5"
   resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz#d0f0e277c512e0c938277faa85a3968c9a44c0e8"
   integrity sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==
 
-"@babel/helper-validator-identifier@^7.18.6":
+"@babel/helper-validator-identifier@^7.15.7", "@babel/helper-validator-identifier@^7.18.6":
   version "7.19.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
   integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
@@ -216,10 +206,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@7.19.0", "@babel/parser@^7.1.0", "@babel/parser@^7.14.5", "@babel/parser@^7.14.6", "@babel/parser@^7.19.0", "@babel/parser@^7.20.7":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.19.0.tgz#497fcafb1d5b61376959c1c338745ef0577aa02c"
-  integrity sha512-74bEXKX2h+8rrfQUfsBfuZZHzsEs6Eql4pqy/T4Nn6Y9wNPggQOqD6z6pn5Bl8ZfysKouFZT/UXEH94ummEeQw==
+"@babel/parser@7.16.0", "@babel/parser@^7.1.0", "@babel/parser@^7.14.5", "@babel/parser@^7.14.6", "@babel/parser@^7.16.0", "@babel/parser@^7.20.7":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.0.tgz#cf147d7ada0a3655e79bf4b08ee846f00a00a295"
+  integrity sha512-TEHWXf0xxpi9wKVyBCmRcSSDjbJ/cl6LUdlbYUHEaNQUJGhreJbZrXT6sR4+fZLxVUJqNRB4KyOvjuy/D9009A==
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
@@ -323,29 +313,27 @@
     "@babel/parser" "^7.20.7"
     "@babel/types" "^7.20.7"
 
-"@babel/traverse@7.19.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.14.5":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.19.0.tgz#eb9c561c7360005c592cc645abafe0c3c4548eed"
-  integrity sha512-4pKpFRDh+utd2mbRC8JLnlsMUii3PMHjpL6a0SZ4NMZy7YFP9aXORxEhdMVOc9CpWtDF09IkciQLEhK7Ml7gRA==
+"@babel/traverse@7.16.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.14.5":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.16.0.tgz#965df6c6bfc0a958c1e739284d3c9fa4a6e3c45b"
+  integrity sha512-qQ84jIs1aRQxaGaxSysII9TuDaguZ5yVrEuC0BN2vcPlalwfLovVmCjbFDPECPXcYM/wLvNFfp8uDOliLxIoUQ==
   dependencies:
-    "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.19.0"
-    "@babel/helper-environment-visitor" "^7.18.9"
-    "@babel/helper-function-name" "^7.19.0"
-    "@babel/helper-hoist-variables" "^7.18.6"
-    "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/parser" "^7.19.0"
-    "@babel/types" "^7.19.0"
+    "@babel/code-frame" "^7.16.0"
+    "@babel/generator" "^7.16.0"
+    "@babel/helper-function-name" "^7.16.0"
+    "@babel/helper-hoist-variables" "^7.16.0"
+    "@babel/helper-split-export-declaration" "^7.16.0"
+    "@babel/parser" "^7.16.0"
+    "@babel/types" "^7.16.0"
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@7.19.0", "@babel/types@^7.0.0", "@babel/types@^7.14.5", "@babel/types@^7.18.6", "@babel/types@^7.19.0", "@babel/types@^7.20.7", "@babel/types@^7.21.0", "@babel/types@^7.21.5", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.19.0.tgz#75f21d73d73dc0351f3368d28db73465f4814600"
-  integrity sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==
+"@babel/types@7.16.0", "@babel/types@^7.0.0", "@babel/types@^7.14.5", "@babel/types@^7.16.0", "@babel/types@^7.18.6", "@babel/types@^7.20.7", "@babel/types@^7.21.0", "@babel/types@^7.21.5", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.16.0.tgz#db3b313804f96aadd0b776c4823e127ad67289ba"
+  integrity sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==
   dependencies:
-    "@babel/helper-string-parser" "^7.18.10"
-    "@babel/helper-validator-identifier" "^7.18.6"
+    "@babel/helper-validator-identifier" "^7.15.7"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":


### PR DESCRIPTION
## Summary:
We use this pattern a lot all over the place.  There was some code for wrapping the return type in parens when it's a object type.  This PR does the same but for values instead of types.

Issue: FEI-5154

## Test plan:
- yarn build
- yarn test