### PR TITLE
Don't annotate array decls as 'unknown' when using --disableFlow

### DIFF
--- a/src/convert/declarations.test.ts
+++ b/src/convert/declarations.test.ts
@@ -825,7 +825,7 @@ describe("transform declarations", () => {
       const arr = []
       `;
       const expected = dedent`
-      const arr: unknown = [];
+      const arr = [];
       `;
 
       expect(

--- a/src/convert/declarations.ts
+++ b/src/convert/declarations.ts
@@ -308,13 +308,7 @@ export function transformDeclarations({
           path.node.init.elements.length === 0 &&
           !path.node.id.typeAnnotation
         ) {
-          if (state.config.disableFlow) {
-            // If flow is disabled, then we don't know, so mark it as unknown.
-            (path.node.id as t.Identifier).typeAnnotation = t.tsTypeAnnotation(
-              t.tsUnknownKeyword()
-            );
-            reporter.disableFlowCheck(state.config.filePath, path.node.id.loc!);
-          } else {
+          if (!state.config.disableFlow) {
             // Ask Flow for the type of our array.
             awaitPromises.push(
               flowTypeAtPos(state, path.node.id.loc!, reporter)


### PR DESCRIPTION
## Summary:
This wasn't an isuse before because we weren't using --dsiableFlow, but the static service is too big to use this option (it slows down the codemod too much).

Issue: None

## Test plan:
- yarn test declarations