### PR TITLE
Convert 'typeof' imports

### DIFF
--- a/src/convert/migrate/import-specifier.test.ts
+++ b/src/convert/migrate/import-specifier.test.ts
@@ -1,0 +1,36 @@
+import { transform } from "../utils/testing";
+
+describe("transform typeof imports", () => {
+  it("import typeof Foo from './foo'", async () => {
+    const src = `import typeof Foo from './foo'`;
+
+    expect(await transform(src)).toMatchInlineSnapshot(
+      `"type Foo = typeof import('./foo');"`
+    );
+  });
+
+  it("named import", async () => {
+    const src = `import typeof {Foo} from './foo'`;
+
+    expect(await transform(src)).toMatchInlineSnapshot(
+      `"type Foo = typeof import('./foo').Foo;"`
+    );
+  });
+
+  it("renamed import", async () => {
+    const src = `import typeof {Foo as Bar} from './foo'`;
+
+    expect(await transform(src)).toMatchInlineSnapshot(
+      `"type Bar = typeof import('./foo').Foo;"`
+    );
+  });
+
+  it("multiple named imports", async () => {
+    const src = `import typeof {Foo as Bar, Baz} from './foo'`;
+
+    expect(await transform(src)).toMatchInlineSnapshot(`
+      "type Bar = typeof import('./foo').Foo;
+      type Baz = typeof import('./foo').Baz;"
+    `);
+  });
+});


### PR DESCRIPTION
## Summary:
We have almost 350 'typeof' imports in webapp.  We can't convert these to regular imports because that would mean we won't be bundle splitting in the same places as before.  This PR updates the codemod to convert 'typeof' imports to TypeScript's type ImportType nodes.

Issue: None

## Test plan:
- yarn test import-specifier