### PR TITLE
Ensure all functional components' return type is React.ReactElement

### DIFF
--- a/src/convert/functional-components.test.ts
+++ b/src/convert/functional-components.test.ts
@@ -123,21 +123,21 @@ describe("Converting functional components", () => {
     it("converts it to an function expression", async () => {
       const src = `function Comp(props: Props) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp = function(props: Props): React.ReactElement { return <h1>Hello</h1> };"`
+        `"function Comp(props: Props): React.ReactElement { return <h1>Hello</h1> };"`
       );
     });
 
     it("works with FooProps", async () => {
       const src = `function Comp(props: FooProps) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp = function(props: FooProps): React.ReactElement { return <h1>Hello</h1> };"`
+        `"function Comp(props: FooProps): React.ReactElement { return <h1>Hello</h1> };"`
       );
     });
 
     it("works with destructured props", async () => {
       const src = `function Comp({foo, bar}: Props) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const Comp = function(
+        "function Comp(
           {
             foo,
             bar,
@@ -149,7 +149,7 @@ describe("Converting functional components", () => {
     it("works on functions with inline props type and React.Node return type", async () => {
       const src = `function Comp(props: {|foo: string, bar: string|}): React.Node { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const Comp = function(
+        "function Comp(
           props: {
             foo: string,
             bar: string
@@ -164,10 +164,10 @@ describe("Converting functional components", () => {
         return <InnerComp />;
       }`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const OuterComp = function(props: OuterProps): React.ReactElement {
-          const InnnerComp = function(props: InnerProps): React.ReactElement { return <h1>Hello</h1>; };
+        "function OuterComp(props: OuterProps): React.ReactElement {
+          function InnnerComp(props: InnerProps): React.ReactElement { return <h1>Hello</h1>; };
           return <InnerComp />;
-        };"
+        }"
       `);
     });
   });
@@ -176,41 +176,78 @@ describe("Converting functional components", () => {
     it("handles named exports", async () => {
       const src = `export function Comp(props: Props) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"export const Comp = function(props: Props): React.ReactElement { return <h1>Hello</h1> };;"`
+        `"export function Comp(props: Props): React.ReactElement { return <h1>Hello</h1> };"`
       );
     });
 
     it("handles default exports with props param", async () => {
       const src = `export default function Comp(props: Props) { return <h1>Hello</h1> };`;
-      expect(await transform(src)).toMatchInlineSnapshot(`
-        "const Comp = function(props: Props): React.ReactElement { return <h1>Hello</h1> };
-        export default Comp;"
-      `);
+      expect(await transform(src)).toMatchInlineSnapshot(
+        `"export default function Comp(props: Props): React.ReactElement { return <h1>Hello</h1> };"`
+      );
     });
 
     it("handles default exports with inline props", async () => {
       const src = `export default function Comp(props: {|foo: string, bar: string|}): React.Node { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const Comp = function(
+        "export default function Comp(
           props: {
             foo: string,
             bar: string
           },
-        ): React.ReactElement { return <h1>Hello</h1> };
-        export default Comp;"
+        ): React.ReactElement { return <h1>Hello</h1> };"
       `);
     });
 
     it("handles default exports with destructured props", async () => {
       const src = `export default function Comp({foo, bar}: Props): React.Node { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const Comp = function(
+        "export default function Comp(
           {
             foo,
             bar,
           }: Props,
-        ): React.ReactElement { return <h1>Hello</h1> };
-        export default Comp;"
+        ): React.ReactElement { return <h1>Hello</h1> };"
+      `);
+    });
+
+    it("should work", async () => {
+      const src = `export function EnrollmentsMetaData(): React.ReactNode {
+        return (
+            <div>
+              Hello, world! 
+            </div>
+        );
+      }`;
+
+      expect(await transform(src)).toMatchInlineSnapshot(`
+        "export function EnrollmentsMetaData(): React.ReactElement {
+                return (
+                    <div>
+                      Hello, world! 
+                    </div>
+                );
+              }"
+      `);
+    });
+
+    it("should also work", async () => {
+      const src = `export const EnrollmentsMetaData = (): React.ReactNode => {
+      return (
+          <div>
+            Hello, world! 
+          </div>
+        );
+      }`;
+
+      expect(await transform(src)).toMatchInlineSnapshot(`
+        "export const EnrollmentsMetaData = (): React.ReactElement => {
+              return (
+                  <div>
+                    Hello, world! 
+                  </div>
+                );
+              }"
       `);
     });
   });

--- a/src/convert/jsx-spread/jsx-spread.test.ts
+++ b/src/convert/jsx-spread/jsx-spread.test.ts
@@ -296,11 +296,11 @@ describe("transform spread JSX attributes", () => {
       foo: number
     };
 
-    const Foobar = function(x: Props): React.ReactElement { 
+    function Foobar(x: Props): React.ReactElement { 
       const { it, ...rest } = x;
       const El = Mine;
       return <El it={it} {...rest} />
-    };`;
+    }`;
 
     expect(
       await transform(

--- a/src/convert/type-annotations.test.ts
+++ b/src/convert/type-annotations.test.ts
@@ -471,7 +471,7 @@ describe("transform type annotations", () => {
 
   it("Converts React.Node to React.ReactElement in normal function", async () => {
     const src = `function Component(props: Props): React.Node {return <div />};`;
-    const expected = `const Component = function(props: Props): React.ReactElement {return <div />};`;
+    const expected = `function Component(props: Props): React.ReactElement {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -480,7 +480,7 @@ describe("transform type annotations", () => {
       if (foo) return (<div />);
       return null;
     };`;
-    const expected = dedent`const Component = function(props: Props): React.ReactElement {
+    const expected = dedent`function Component(props: Props): React.ReactElement {
       if (foo) return (<div />);
       return null;
     };`;


### PR DESCRIPTION
## Summary:
We weren't processing functional components with non params.  This PR fixes that.

This PR also updates how we process functional components so that it doesn't convert function declarations to variable declarations + function expression.  This will reduce the number of changes in files made by the codemod.  Also, a number of people have expressed a preference for function declaration and I don't want to unilaterally change their code without a very good reason.

NOTE: The code could be simplified further since we no longer need to consider whether a functional component is being exported or not when processing it.  I'm punting on this for now since it doesn't move things forwards with the TS migration.

Issue: None

## Test plan:
- yarn build
- yarn test