### PR TITLE
FEI-5159: Update jest tests to import jest globals from @jest/globals

### DIFF
--- a/src/convert/transform-runners.ts
+++ b/src/convert/transform-runners.ts
@@ -13,6 +13,7 @@ import { removeFlowComments } from "./remove-flow-comments";
 import { annotateNoFlow } from "./annotate-no-flow";
 import { transformFunctionalComponents } from "./functional-components";
 import { transformFilterBoolean } from "./migrate/filter-boolean";
+import { importJestGlobals } from "./import-jest-globals";
 
 const standardTransformRunnerFactory = (transformer: Transformer) => {
   return (transformerInput: TransformerInput) => {
@@ -70,3 +71,6 @@ export const functionalComponentTransformerRunner: Transformer = async (
 
 export const filterBooleanTranforRunner: Transformer =
   standardTransformRunnerFactory(transformFilterBoolean);
+
+export const importJestGlobalsTransformRunner: Transformer =
+  standardTransformRunnerFactory(importJestGlobals);

--- a/src/convert/utils/testing.ts
+++ b/src/convert/utils/testing.ts
@@ -6,7 +6,10 @@ import { recastOptions } from "../../runner/process-batch";
 import { runTransforms } from "../../runner/run-transforms";
 import MigrationReporter from "../../runner/migration-reporter";
 import { defaultTransformerChain } from "../default-transformer-chain";
-import { watermarkTransformRunner } from "../transform-runners";
+import {
+  importJestGlobalsTransformRunner,
+  watermarkTransformRunner,
+} from "../transform-runners";
 import { Transformer } from "../transformer";
 import { State } from "../../runner/state";
 import { ConfigurableTypeProvider } from "./configurable-type-provider";
@@ -26,7 +29,12 @@ const MockedMigrationReporter =
 const transform = async (code: string, state?: State) => {
   state = state ?? stateBuilder();
 
-  const transforms = defaultTransformerChain;
+  const transforms = [...defaultTransformerChain];
+
+  if (state.config.filePath.includes("_test.")) {
+    transforms.push(importJestGlobalsTransformRunner);
+  }
+
   return transformRunner(code, state, transforms);
 };
 

--- a/src/runner/process-batch.ts
+++ b/src/runner/process-batch.ts
@@ -11,6 +11,7 @@ import { defaultTransformerChain } from "../convert/default-transformer-chain";
 import {
   annotateNoFlowTransformRunner,
   watermarkTransformRunner,
+  importJestGlobalsTransformRunner,
 } from "../convert/transform-runners";
 import { State } from "./state";
 import { ConfigurableTypeProvider } from "../convert/utils/configurable-type-provider";
@@ -123,6 +124,10 @@ export async function processBatchAsync(
           options.convertUnannotated
         ) {
           transforms.push(annotateNoFlowTransformRunner);
+        }
+
+        if (filePath.includes("_test.")) {
+          transforms.push(importJestGlobalsTransformRunner);
         }
 
         await runTransforms(reporter, state, file, transforms);


### PR DESCRIPTION
## Summary:
We want to explicitly import all of the jest globals so that they can't interfere with the cypress globals.  This PR updates the codemod to do exactly that.

Issue: FEI-5159

## Test plan:
- yarn test
- yarn build