### PR TITLE
fix 'import typeof' transform to import 'default'

### DIFF
--- a/src/convert/declarations.test.ts
+++ b/src/convert/declarations.test.ts
@@ -21,7 +21,7 @@ describe("transform declarations", () => {
     jest.clearAllMocks();
   });
 
-  describe.only("import declarations", () => {
+  describe("import declarations", () => {
     it("does not transforms type imports", async () => {
       const src = `import type {foo} from './foo';`;
       const expected = `import type {foo} from './foo';`;

--- a/src/convert/declarations.test.ts
+++ b/src/convert/declarations.test.ts
@@ -21,7 +21,7 @@ describe("transform declarations", () => {
     jest.clearAllMocks();
   });
 
-  describe("import declarations", () => {
+  describe.only("import declarations", () => {
     it("does not transforms type imports", async () => {
       const src = `import type {foo} from './foo';`;
       const expected = `import type {foo} from './foo';`;
@@ -33,7 +33,7 @@ describe("transform declarations", () => {
         const src = `import typeof Foo from './foo'`;
 
         expect(await transform(src)).toMatchInlineSnapshot(
-          `"type Foo = typeof import('./foo');"`
+          `"type Foo = typeof import('./foo').default;"`
         );
       });
 

--- a/src/convert/type-annotations.ts
+++ b/src/convert/type-annotations.ts
@@ -128,7 +128,7 @@ export function transformTypeAnnotations({
               t.tsTypeAliasDeclaration(
                 local,
                 undefined,
-                t.tsTypeQuery(t.tsImportType(source))
+                t.tsTypeQuery(t.tsImportType(source, t.identifier("default")))
               ),
             ];
           } else {


### PR DESCRIPTION
## Summary:
It turns out that TS import types work like namespace imports.  This PR makes sure we're grabbing the type of the 'default' epxort when converting a default typeof import.

Issue: None

## Test plan:
- yarn test declarations
- yarn build