### PR TITLE
Handle existing local .d.ts files

### DIFF
--- a/src/runner/find-flow-files.ts
+++ b/src/runner/find-flow-files.ts
@@ -21,7 +21,11 @@ export enum FlowFileType {
   NO_ANNOTATION,
 }
 
-export type FlowFileList = Array<{ filePath: string; fileType: FlowFileType }>;
+export type FlowFileList = Array<{
+  filePath: string;
+  fileType: FlowFileType;
+  skipDelete?: boolean;
+}>;
 
 /**
  * Finds all of the Flow files in the provided directory as efficiently as

--- a/src/runner/find-flow-files.ts
+++ b/src/runner/find-flow-files.ts
@@ -21,11 +21,7 @@ export enum FlowFileType {
   NO_ANNOTATION,
 }
 
-export type FlowFileList = Array<{
-  filePath: string;
-  fileType: FlowFileType;
-  skipDelete?: boolean;
-}>;
+export type FlowFileList = Array<{ filePath: string; fileType: FlowFileType }>;
 
 /**
  * Finds all of the Flow files in the provided directory as efficiently as

--- a/src/runner/process-batch.ts
+++ b/src/runner/process-batch.ts
@@ -49,7 +49,8 @@ export async function processBatchAsync(
   options: ConvertCommandCliArgs
 ) {
   await Promise.all(
-    filePaths.map(async ({ filePath, fileType }) => {
+    filePaths.map(async (elem) => {
+      const { filePath, fileType } = elem;
       try {
         if (
           (fileType === FlowFileType.NO_FLOW && options.skipNoFlow) ||
@@ -70,6 +71,18 @@ export async function processBatchAsync(
         // if there is one.
         if (fs.existsSync(filePath.replace(/\.jsx?$/, ".tsx"))) {
           reporter.foundDeclarationFile(filePath);
+          return;
+        }
+
+        // Checks if a .d.ts override file exists and stops early
+        // if there is one.
+        if (fs.existsSync(filePath.replace(/\.jsx?$/, ".d.ts"))) {
+          reporter.foundDeclarationFile(filePath);
+          // .d.ts files can live side-by-side with .js(x) files, providing
+          // types for the .ts(x) files that import them so we need to
+          // keep the .js(x) file around since that's what contains the
+          // implementation.
+          elem.skipDelete = true;
           return;
         }
 

--- a/src/runner/process-batch.ts
+++ b/src/runner/process-batch.ts
@@ -76,13 +76,12 @@ export async function processBatchAsync(
 
         // Checks if a .d.ts override file exists and stops early
         // if there is one.
+        // .d.ts files can live side-by-side with .js(x) files, providing
+        // types for the .ts(x) files that import them so we need to
+        // keep the .js(x) file around since that's what contains the
+        // implementation.
         if (fs.existsSync(filePath.replace(/\.jsx?$/, ".d.ts"))) {
           reporter.foundDeclarationFile(filePath);
-          // .d.ts files can live side-by-side with .js(x) files, providing
-          // types for the .ts(x) files that import them so we need to
-          // keep the .js(x) file around since that's what contains the
-          // implementation.
-          elem.skipDelete = true;
           return;
         }
 

--- a/src/runner/run-primary-async.ts
+++ b/src/runner/run-primary-async.ts
@@ -202,8 +202,8 @@ export async function runPrimaryAsync(options: ConvertCommandCliArgs) {
             options.skipNoFlow) ||
           (flowFilePath.fileType === FlowFileType.NO_ANNOTATION &&
             !options.convertUnannotated) ||
-          // set when processing .js files that have a corresponding .d.ts files
-          !!flowFilePath.skipDelete;
+          // skip .js(x) files that have a corresponding .d.ts file
+          fs.existsSync(flowFilePath.filePath.replace(/\.jsx?$/, ".d.ts"));
 
         if (!wasSkipped) {
           toRemoveCalls.push(fs.remove(flowFilePath.filePath));

--- a/src/runner/run-primary-async.ts
+++ b/src/runner/run-primary-async.ts
@@ -201,7 +201,9 @@ export async function runPrimaryAsync(options: ConvertCommandCliArgs) {
           (flowFilePath.fileType === FlowFileType.NO_FLOW &&
             options.skipNoFlow) ||
           (flowFilePath.fileType === FlowFileType.NO_ANNOTATION &&
-            !options.convertUnannotated);
+            !options.convertUnannotated) ||
+          // set when processing .js files that have a corresponding .d.ts files
+          !!flowFilePath.skipDelete;
 
         if (!wasSkipped) {
           toRemoveCalls.push(fs.remove(flowFilePath.filePath));


### PR DESCRIPTION
## Summary:
There is at least one place where we have a .js.flow file that lives beside the regular .js file provide types for it.  This allows us to provide types for an untyped for without having to add types to the file itself.  TypeScript supports this as well with .d.ts files.  This PR updates the codemod to support this pattern.

Issue: None

## Test plan:
- run the codemod after creating a .d.ts version of backbone-lite.js.flow in webapp, see that the .js implementation file isn't deleted

<img width="426" alt="Screen Shot 2023-06-01 at 11 16 22 AM" src="https://github.com/Khan/flow-to-typescript-codemod/assets/1044413/7055482e-afce-4487-86ac-ba0e45eb5aa7">
