### PR TITLE
Delete files in flow-typed directory without converting them to TypeScript

### DIFF
--- a/src/runner/find-flow-files.ts
+++ b/src/runner/find-flow-files.ts
@@ -161,7 +161,7 @@ export function findFlowFilesAsync(
           }
           // If the buffer has the @flow pragma then add the file path to our
           // final file paths array.
-          if (buffer.includes("@flow")) {
+          if (buffer.includes("@flow") || filePath.includes("flow-typed")) {
             filePaths.push({ filePath, fileType: FlowFileType.FLOW });
           } else if (buffer.includes("@noflow")) {
             filePaths.push({ filePath, fileType: FlowFileType.NO_FLOW });

--- a/src/runner/process-batch.ts
+++ b/src/runner/process-batch.ts
@@ -85,6 +85,11 @@ export async function processBatchAsync(
           return;
         }
 
+        // ignore files in flow-typed directory
+        if (filePath.includes("flow-typed")) {
+          return;
+        }
+
         const fileBuffer = await fs.readFile(filePath);
 
         const fileText = fileBuffer.toString("utf8");


### PR DESCRIPTION
## Summary:
The codemod doesn't process Flow lib defs properly and it doesn't make sense to have it process them anyways because a bunch of packages ship with TypeScript types or we're installing .d.ts files for those that don't from DefinitelyTyped.

Issue: None

## Test plan:
- run the codemod, see that all of the files in flow-typed/ have been deleted