### PR TITLE
Don't transform files in the third_party directory

### DIFF
--- a/src/runner/find-flow-files.ts
+++ b/src/runner/find-flow-files.ts
@@ -143,6 +143,10 @@ export function findFlowFilesAsync(
       if (rejected === true) {
         return;
       }
+      // Skip third party files
+      if (filePath.includes("/third_party/")) {
+        return;
+      }
       // We are now waiting on this asynchronous task.
       waiting++;
       // Open the file path.


### PR DESCRIPTION
## Summary:
Although there's probably a way to do this via the CLI, building this into the codemod itself means we don't hhave to remember to pass this as part of some ignore list or figure out if the ignore list takes patterns or if you have to provide it a complete path or not.

Issue: None

## Test plan:
- run the codemod
- see that none of the files in services/static/third_party/ in webapp have been transformed