### PR TITLE
FEI-5177: Handle more edge cases when handling React.Node

### DIFF
--- a/src/convert/declarations.test.ts
+++ b/src/convert/declarations.test.ts
@@ -565,16 +565,6 @@ describe("transform declarations", () => {
     expect(await transform(src)).toBe(expected);
   });
 
-  it("Converts React.Element<'div'> to React.ReactElement in render", async () => {
-    const src = dedent`class Foo extends React.Component {
-      render(): React.Element<"div"> {return <div />};
-    };`;
-    const expected = dedent`class Foo extends React.Component {
-      render(): React.ReactNode {return <div />};
-    };`;
-    expect(await transform(src)).toBe(expected);
-  });
-
   it("Adds null to React.ReactElement in render", async () => {
     const src = dedent`class Foo extends React.Component {
       render(): React.Node {
@@ -582,23 +572,25 @@ describe("transform declarations", () => {
         return null;
       };
     };`;
-    const expected = dedent`class Foo extends React.Component {
-      render(): React.ReactNode | null {
-        if (foo) return (<div />);
-        return null;
-      };
-    };`;
-    expect(await transform(src)).toBe(expected);
+    expect(await transform(src)).toMatchInlineSnapshot(`
+      "class Foo extends React.Component {
+        render(): React.ReactNode {
+          if (foo) return (<div />);
+          return null;
+        };
+      };"
+    `);
   });
 
   it("Converts React.Node to React.ReactElement for render in arrow", async () => {
     const src = dedent`class Foo extends React.Component {
       render = (): React.Node => {return <div />};
     };`;
-    const expected = dedent`class Foo extends React.Component {
-      render = (): React.ReactNode => {return <div />};
-    };`;
-    expect(await transform(src)).toBe(expected);
+    expect(await transform(src)).toMatchInlineSnapshot(`
+      "class Foo extends React.Component {
+        render = (): React.ReactElement => {return <div />};
+      };"
+    `);
   });
 
   it("Does not convert React.Node to React.ReactElement in non-render", async () => {

--- a/src/convert/functional-components.test.ts
+++ b/src/convert/functional-components.test.ts
@@ -6,29 +6,29 @@ jest.mock("./flow/type-at-pos.ts");
 
 describe("Converting functional components", () => {
   describe("Arrow functions", () => {
-    it("adds return type annotation", async () => {
+    it("doesn't add return type annotation if there wasn't one to begin with", async () => {
       const src = `const Comp = (props: Props) => { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp = (props: Props): React.ReactElement => { return <h1>Hello</h1> };"`
+        `"const Comp = (props: Props) => { return <h1>Hello</h1> };"`
       );
     });
 
     it("works with FooProps", async () => {
-      const src = `const Comp = (props: FooProps) => { return <h1>Hello</h1> };`;
+      const src = `const Comp = (props: FooProps): React.Node => { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
         `"const Comp = (props: FooProps): React.ReactElement => { return <h1>Hello</h1> };"`
       );
     });
 
     it("works on lambdas", async () => {
-      const src = `const Comp = (props: FooProps) => <h1>Hello</h1>;`;
+      const src = `const Comp = (props: FooProps): React.Node => <h1>Hello</h1>;`;
       expect(await transform(src)).toMatchInlineSnapshot(
         `"const Comp = (props: FooProps): React.ReactElement => <h1>Hello</h1>;"`
       );
     });
 
     it("works with destructured props", async () => {
-      const src = `const Comp = ({foo, bar}: Props) => { return <h1>Hello</h1> };`;
+      const src = `const Comp = ({foo, bar}: Props): React.Node => { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(`
         "const Comp = (
           {
@@ -69,26 +69,24 @@ describe("Converting functional components", () => {
     it("adds return type annotation", async () => {
       const src = `const Comp = function (props: Props) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp = function(props: Props): React.ReactElement { return <h1>Hello</h1> };"`
+        `"const Comp = function (props: Props) { return <h1>Hello</h1> };"`
       );
     });
 
     it("works with FooProps", async () => {
       const src = `const Comp = function (props: FooProps) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
-        `"const Comp = function(props: FooProps): React.ReactElement { return <h1>Hello</h1> };"`
+        `"const Comp = function (props: FooProps) { return <h1>Hello</h1> };"`
       );
     });
 
     it("works with destructured props", async () => {
       const src = `const Comp = function ({foo, bar}: Props) { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(`
-        "const Comp = function(
-          {
-            foo,
-            bar,
-          }: Props,
-        ): React.ReactElement { return <h1>Hello</h1> };"
+        "const Comp = function ({
+          foo,
+          bar,
+        }: Props) { return <h1>Hello</h1> };"
       `);
     });
 
@@ -112,7 +110,7 @@ describe("Converting functional components", () => {
       }`;
       expect(await transform(src)).toMatchInlineSnapshot(`
         "const OuterComp = function(props: OuterProps): React.ReactElement {
-          const InnnerComp = function(props: InnerProps): React.ReactElement { return <h1>Hello</h1>; };
+          const InnnerComp = function (props: InnerProps) { return <h1>Hello</h1>; };
           return <InnerComp />;
         }"
       `);
@@ -121,21 +119,21 @@ describe("Converting functional components", () => {
 
   describe("Function declarations", () => {
     it("converts it to an function expression", async () => {
-      const src = `function Comp(props: Props) { return <h1>Hello</h1> };`;
+      const src = `function Comp(props: Props): React.Node { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
         `"function Comp(props: Props): React.ReactElement { return <h1>Hello</h1> };"`
       );
     });
 
     it("works with FooProps", async () => {
-      const src = `function Comp(props: FooProps) { return <h1>Hello</h1> };`;
+      const src = `function Comp(props: FooProps): React.Node { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
         `"function Comp(props: FooProps): React.ReactElement { return <h1>Hello</h1> };"`
       );
     });
 
     it("works with destructured props", async () => {
-      const src = `function Comp({foo, bar}: Props) { return <h1>Hello</h1> };`;
+      const src = `function Comp({foo, bar}: Props): React.Node { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(`
         "function Comp(
           {
@@ -165,7 +163,7 @@ describe("Converting functional components", () => {
       }`;
       expect(await transform(src)).toMatchInlineSnapshot(`
         "function OuterComp(props: OuterProps): React.ReactElement {
-          function InnnerComp(props: InnerProps): React.ReactElement { return <h1>Hello</h1>; };
+          function InnnerComp(props: InnerProps) { return <h1>Hello</h1>; };
           return <InnerComp />;
         }"
       `);
@@ -174,14 +172,14 @@ describe("Converting functional components", () => {
 
   describe("Exporting function", () => {
     it("handles named exports", async () => {
-      const src = `export function Comp(props: Props) { return <h1>Hello</h1> };`;
+      const src = `export function Comp(props: Props): React.Node { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
         `"export function Comp(props: Props): React.ReactElement { return <h1>Hello</h1> };"`
       );
     });
 
     it("handles default exports with props param", async () => {
-      const src = `export default function Comp(props: Props) { return <h1>Hello</h1> };`;
+      const src = `export default function Comp(props: Props): React.Node { return <h1>Hello</h1> };`;
       expect(await transform(src)).toMatchInlineSnapshot(
         `"export default function Comp(props: Props): React.ReactElement { return <h1>Hello</h1> };"`
       );
@@ -248,6 +246,32 @@ describe("Converting functional components", () => {
                   </div>
                 );
               }"
+      `);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("contains no JSX", async () => {
+      const src = `export default (props: Props): React.ReactNode => { return null; };`;
+
+      expect(await transform(src)).toMatchInlineSnapshot(
+        `"export default (props: Props): React.ReactElement | null => { return null; };"`
+      );
+    });
+
+    it("ApolloQuery", async () => {
+      const src = `export default function <TData: {...}, TVariables: {...}>(
+        props: WithoutApollo<Props<TData, TVariables>>,
+    ): React.Node {
+        return <ApolloQueryWithContext {...props} />;
+    }
+    `;
+
+      expect(await transform(src)).toMatchInlineSnapshot(`
+        "export default function<TData extends Record<any, any>, TVariables extends Record<any, any>>(props: WithoutApollo<Props<TData, TVariables>>): React.ReactElement {
+                return <ApolloQueryWithContext {...props} />;
+            }
+            "
       `);
     });
   });

--- a/src/convert/functional-components.ts
+++ b/src/convert/functional-components.ts
@@ -2,243 +2,157 @@ import * as t from "@babel/types";
 import traverse from "@babel/traverse";
 
 import { TransformerInput } from "./transformer";
+import { hasNullReturn } from "./utils/common";
 
 export function transformFunctionalComponents({
   file,
 }: TransformerInput): Promise<unknown> {
   const awaitPromises: Array<Promise<unknown>> = [];
 
-  // We only want to add `React.ReactElement` as a return type on functions that
-  // we know are React components.  Checking if there's a param named `props` is
-  // not enough to determine this since `mapPropsToState` and `mapPropsToDispatch`
-  // both take `props` as param but are not components.  In order to determine if
-  // a function is a component, we also need to check if returns any JSX.  In order
-  // to do this, we need to track if there's any JSXElements in each scope.
-  const initialState: { scopes: Array<{ jsx: boolean }> } = { scopes: [] };
+  traverse(file, {
+    FunctionExpression(path) {
+      const { params, returnType, body } = path.node;
 
-  traverse(
-    file,
-    {
-      JSXElement: {
-        exit(_, state) {
-          if (state.scopes.length > 0) {
-            state.scopes[state.scopes.length - 1].jsx = true;
-          }
-        },
-      },
-      FunctionExpression: {
-        enter(_, state) {
-          state.scopes.push({ jsx: false });
-        },
-        exit(path, state) {
-          const containsJsx = state.scopes[state.scopes.length - 1].jsx;
-          // We only want to modify the node if the function contains JSX otherwise
-          // it messes up the conversion of other functions, even if `containsJsx` is
-          // set to false.
-          if (containsJsx) {
-            // @ts-expect-error: containsJsx is a custom property we're adding
-            path.node.containsJsx = containsJsx;
-          }
-          state.scopes.pop();
-        },
-      },
-      ArrowFunctionExpression: {
-        enter(_, state) {
-          state.scopes.push({ jsx: false });
-        },
-        exit(path, state) {
-          const containsJsx = state.scopes[state.scopes.length - 1].jsx;
-          // We only want to modify the node if the function contains JSX otherwise
-          // it messes up the conversion of other functions, even if `containsJsx` is
-          // set to false.
-          if (containsJsx) {
-            // @ts-expect-error: containsJsx is a custom property we're adding
-            path.node.containsJsx = containsJsx;
-          }
-          state.scopes.pop();
-        },
-      },
-      VariableDeclarator: {
-        exit(path) {
-          if (
-            (t.isArrowFunctionExpression(path.node.init) ||
-              t.isFunctionExpression(path.node.init)) &&
-            // @ts-expect-error: containsJsx is a custom property we're adding
-            path.node.init.containsJsx
-          ) {
-            const { id, init: arrowFn } = path.node;
-            const { params, returnType } = arrowFn;
+      const hasNull = hasNullReturn(
+        body as t.BlockStatement,
+        path.scope,
+        path.parentPath
+      );
 
-            if (params.length === 0 && returnType) {
-              if (
-                t.isIdentifier(id) &&
-                t.isTSTypeAnnotation(returnType) &&
-                t.isTSTypeReference(returnType.typeAnnotation) &&
-                t.isTSQualifiedName(returnType.typeAnnotation.typeName) &&
-                t.isIdentifier(returnType.typeAnnotation.typeName.left, {
-                  name: "React",
-                }) &&
-                t.isIdentifier(returnType.typeAnnotation.typeName.right) &&
-                returnType.typeAnnotation.typeName.right.name === "ReactNode"
-              ) {
-                arrowFn.returnType = createReturnType();
-              }
-            } else if (params.length === 1) {
-              const [param] = params;
+      if (params.length === 0) {
+        if (
+          t.isTSTypeAnnotation(returnType) &&
+          t.isTSTypeReference(returnType.typeAnnotation) &&
+          t.isTSQualifiedName(returnType.typeAnnotation.typeName) &&
+          t.isIdentifier(returnType.typeAnnotation.typeName.left, {
+            name: "React",
+          }) &&
+          t.isIdentifier(returnType.typeAnnotation.typeName.right) &&
+          returnType.typeAnnotation.typeName.right.name === "ReactNode"
+        ) {
+          path.node.returnType = createReturnType(hasNull);
+        }
+      } else if (params.length === 1) {
+        const [param] = params;
 
-              if (
-                (t.isIdentifier(id) &&
-                  t.isTSTypeAnnotation(param.typeAnnotation) &&
-                  t.isTSTypeReference(param.typeAnnotation.typeAnnotation) &&
-                  t.isIdentifier(
-                    param.typeAnnotation.typeAnnotation.typeName
-                  ) &&
-                  param.typeAnnotation.typeAnnotation.typeName.name.endsWith(
-                    "Props"
-                  )) ||
-                (t.isIdentifier(id) &&
-                  t.isTSTypeAnnotation(param.typeAnnotation) &&
-                  t.isTSTypeAnnotation(arrowFn.returnType) &&
-                  t.isTSTypeReference(arrowFn.returnType.typeAnnotation) &&
-                  t.isTSQualifiedName(
-                    arrowFn.returnType.typeAnnotation.typeName
-                  ) &&
-                  t.isIdentifier(
-                    arrowFn.returnType.typeAnnotation.typeName.left,
-                    {
-                      name: "React",
-                    }
-                  ) &&
-                  t.isIdentifier(
-                    arrowFn.returnType.typeAnnotation.typeName.right
-                  ) &&
-                  arrowFn.returnType.typeAnnotation.typeName.right.name ===
-                    "ReactNode")
-              ) {
-                // We always include a return type so that the output code conforms to
-                // https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/2201682700/TypeScript+Best+Practices#Functions-should-have-return-types
-                arrowFn.returnType = createReturnType();
-              }
-            }
-          }
-        },
-      },
-      FunctionDeclaration: {
-        enter(_, state) {
-          state.scopes.push({ jsx: false });
-        },
-        exit(path, state) {
-          if (!t.isExportDefaultDeclaration(path.parent)) {
-            const { id, params, returnType } = path.node;
-
-            if (
-              state.scopes.length > 0 &&
-              !state.scopes[state.scopes.length - 1].jsx
-            ) {
-              return;
-            }
-
-            if (params.length === 0) {
-              if (
-                t.isIdentifier(id) &&
-                t.isTSTypeAnnotation(returnType) &&
-                t.isTSTypeReference(returnType.typeAnnotation) &&
-                t.isTSQualifiedName(returnType.typeAnnotation.typeName) &&
-                t.isIdentifier(returnType.typeAnnotation.typeName.left, {
-                  name: "React",
-                }) &&
-                t.isIdentifier(returnType.typeAnnotation.typeName.right) &&
-                returnType.typeAnnotation.typeName.right.name === "ReactNode"
-              ) {
-                path.node.returnType = createReturnType();
-              }
-            } else if (params.length === 1) {
-              const [param] = params;
-
-              if (
-                (t.isIdentifier(id) &&
-                  t.isTSTypeAnnotation(param.typeAnnotation) &&
-                  t.isTSTypeReference(param.typeAnnotation.typeAnnotation) &&
-                  t.isIdentifier(
-                    param.typeAnnotation.typeAnnotation.typeName
-                  ) &&
-                  param.typeAnnotation.typeAnnotation.typeName.name.endsWith(
-                    "Props"
-                  )) ||
-                (t.isIdentifier(id) &&
-                  t.isTSTypeAnnotation(param.typeAnnotation) &&
-                  t.isTSTypeAnnotation(returnType) &&
-                  t.isTSTypeReference(returnType.typeAnnotation) &&
-                  t.isTSQualifiedName(returnType.typeAnnotation.typeName) &&
-                  t.isIdentifier(returnType.typeAnnotation.typeName.left, {
-                    name: "React",
-                  }) &&
-                  t.isIdentifier(returnType.typeAnnotation.typeName.right) &&
-                  returnType.typeAnnotation.typeName.right.name === "ReactNode")
-              ) {
-                // We always include a return type so that the output code conforms to
-                // https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/2201682700/TypeScript+Best+Practices#Functions-should-have-return-types
-                path.node.returnType = createReturnType();
-              }
-            }
-          }
-
-          state.scopes.pop();
-        },
-      },
-      ExportDefaultDeclaration: {
-        exit(path) {
-          const { node } = path;
-          if (t.isFunctionDeclaration(node.declaration)) {
-            const { id, params, returnType } = node.declaration;
-            if (params.length === 1) {
-              const [param] = params;
-
-              if (
-                (t.isIdentifier(id) &&
-                  t.isTSTypeAnnotation(param.typeAnnotation) &&
-                  t.isTSTypeReference(param.typeAnnotation.typeAnnotation) &&
-                  t.isIdentifier(
-                    param.typeAnnotation.typeAnnotation.typeName
-                  ) &&
-                  param.typeAnnotation.typeAnnotation.typeName.name.endsWith(
-                    "Props"
-                  )) ||
-                (t.isIdentifier(id) &&
-                  t.isTSTypeAnnotation(param.typeAnnotation) &&
-                  t.isTSTypeAnnotation(returnType) &&
-                  t.isTSTypeReference(returnType.typeAnnotation) &&
-                  t.isTSQualifiedName(returnType.typeAnnotation.typeName) &&
-                  t.isIdentifier(returnType.typeAnnotation.typeName.left, {
-                    name: "React",
-                  }) &&
-                  t.isIdentifier(returnType.typeAnnotation.typeName.right) &&
-                  returnType.typeAnnotation.typeName.right.name === "ReactNode")
-              ) {
-                node.declaration.returnType = createReturnType();
-              }
-            }
-          }
-        },
-      },
+        if (
+          t.isTSTypeAnnotation(param.typeAnnotation) &&
+          t.isTSTypeAnnotation(returnType) &&
+          t.isTSTypeReference(returnType.typeAnnotation) &&
+          t.isTSQualifiedName(returnType.typeAnnotation.typeName) &&
+          t.isIdentifier(returnType.typeAnnotation.typeName.left, {
+            name: "React",
+          }) &&
+          t.isIdentifier(returnType.typeAnnotation.typeName.right) &&
+          returnType.typeAnnotation.typeName.right.name === "ReactNode"
+        ) {
+          // We always include a return type so that the output code conforms to
+          // https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/2201682700/TypeScript+Best+Practices#Functions-should-have-return-types
+          path.node.returnType = createReturnType(hasNull);
+        }
+      }
     },
-    undefined,
-    initialState
-  );
+    ArrowFunctionExpression(path) {
+      const { params, returnType, body } = path.node;
+
+      const hasNull = hasNullReturn(
+        body as t.BlockStatement,
+        path.scope,
+        path.parentPath
+      );
+
+      if (params.length === 0) {
+        if (
+          t.isTSTypeAnnotation(returnType) &&
+          t.isTSTypeReference(returnType.typeAnnotation) &&
+          t.isTSQualifiedName(returnType.typeAnnotation.typeName) &&
+          t.isIdentifier(returnType.typeAnnotation.typeName.left, {
+            name: "React",
+          }) &&
+          t.isIdentifier(returnType.typeAnnotation.typeName.right) &&
+          returnType.typeAnnotation.typeName.right.name === "ReactNode"
+        ) {
+          path.node.returnType = createReturnType(hasNull);
+        }
+      } else if (params.length === 1) {
+        const [param] = params;
+
+        if (
+          t.isTSTypeAnnotation(param.typeAnnotation) &&
+          t.isTSTypeAnnotation(returnType) &&
+          t.isTSTypeReference(returnType.typeAnnotation) &&
+          t.isTSQualifiedName(returnType.typeAnnotation.typeName) &&
+          t.isIdentifier(returnType.typeAnnotation.typeName.left, {
+            name: "React",
+          }) &&
+          t.isIdentifier(returnType.typeAnnotation.typeName.right) &&
+          returnType.typeAnnotation.typeName.right.name === "ReactNode"
+        ) {
+          // We always include a return type so that the output code conforms to
+          // https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/2201682700/TypeScript+Best+Practices#Functions-should-have-return-types
+          path.node.returnType = createReturnType(hasNull);
+        }
+      }
+    },
+    FunctionDeclaration(path) {
+      const { params, returnType, body } = path.node;
+
+      const hasNull = hasNullReturn(
+        body as t.BlockStatement,
+        path.scope,
+        path.parentPath
+      );
+
+      if (params.length === 0) {
+        if (
+          t.isTSTypeAnnotation(returnType) &&
+          t.isTSTypeReference(returnType.typeAnnotation) &&
+          t.isTSQualifiedName(returnType.typeAnnotation.typeName) &&
+          t.isIdentifier(returnType.typeAnnotation.typeName.left, {
+            name: "React",
+          }) &&
+          t.isIdentifier(returnType.typeAnnotation.typeName.right) &&
+          returnType.typeAnnotation.typeName.right.name === "ReactNode"
+        ) {
+          path.node.returnType = createReturnType(hasNull);
+        }
+      } else if (params.length === 1) {
+        const [param] = params;
+
+        if (
+          t.isTSTypeAnnotation(param.typeAnnotation) &&
+          t.isTSTypeAnnotation(returnType) &&
+          t.isTSTypeReference(returnType.typeAnnotation) &&
+          t.isTSQualifiedName(returnType.typeAnnotation.typeName) &&
+          t.isIdentifier(returnType.typeAnnotation.typeName.left, {
+            name: "React",
+          }) &&
+          t.isIdentifier(returnType.typeAnnotation.typeName.right) &&
+          returnType.typeAnnotation.typeName.right.name === "ReactNode"
+        ) {
+          // We always include a return type so that the output code conforms to
+          // https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/2201682700/TypeScript+Best+Practices#Functions-should-have-return-types
+          path.node.returnType = createReturnType(hasNull);
+        }
+      }
+    },
+  });
 
   return Promise.all(awaitPromises);
 }
 
-function createReturnType() {
-  return t.tsTypeAnnotation(
-    t.tsTypeReference(
-      t.tsQualifiedName(
-        // Using `React.ReactNode` as the return type is incompatible
-        // with `React.FC<>` so we return `React.ReactElement`.  The
-        // actual return type of `React.FC<>` is `React.ReactElement | null`.
-        t.identifier("React"),
-        t.identifier("ReactElement")
-      )
+function createReturnType(hasNull: boolean) {
+  const reactElement = t.tsTypeReference(
+    t.tsQualifiedName(
+      // Using `React.ReactNode` as the return type is incompatible
+      // with `React.FC<>` so we return `React.ReactElement`.  The
+      // actual return type of `React.FC<>` is `React.ReactElement | null`.
+      t.identifier("React"),
+      t.identifier("ReactElement")
     )
+  );
+
+  return t.tsTypeAnnotation(
+    hasNull ? t.tsUnionType([reactElement, t.tsNullKeyword()]) : reactElement
   );
 }

--- a/src/convert/hoc.test.ts
+++ b/src/convert/hoc.test.ts
@@ -117,14 +117,12 @@ describe("transform HOC patterns", () => {
         qux: string
       };
 
-      const InternalComponent = (
-        {
-          foo,
-          bar,
-          baz,
-          qux = \\"hello\\",
-        }: Props,
-      ): React.ReactElement => {
+      const InternalComponent = ({
+        foo,
+        bar,
+        baz,
+        qux = \\"hello\\",
+      }: Props) => {
         return (
           <div>
             foo: {foo}

--- a/src/convert/jsx-spread/jsx-spread.test.ts
+++ b/src/convert/jsx-spread/jsx-spread.test.ts
@@ -296,7 +296,7 @@ describe("transform spread JSX attributes", () => {
       foo: number
     };
 
-    function Foobar(x: Props): React.ReactElement { 
+    function Foobar(x: Props) { 
       const { it, ...rest } = x;
       const El = Mine;
       return <El it={it} {...rest} />

--- a/src/convert/migrate/type.ts
+++ b/src/convert/migrate/type.ts
@@ -523,70 +523,70 @@ function actuallyMigrateType(
       // In TS, if you say a function returns React.ReactNode, it cannot be used as a <JSXElement /> due to conflicts with the JSX types.
       // The best return type appears to be React.ReactElement, and you have to declare null if it also returns null
       // So we check if we're in a function / render function return, and check for a null return in the function, before annotating.
-      let isRenderMethodOrNonClassMethodReturnType =
-        metaData?.returnType ?? false;
+      // let isRenderMethodOrNonClassMethodReturnType =
+      //   metaData?.returnType ?? false;
 
-      if (metaData?.path && metaData.path.parentPath) {
-        const parent = metaData.path.parentPath;
-        if (
-          parent.node.type === "ClassMethod" &&
-          parent.node.key.type === "Identifier" &&
-          parent.node.key.name !== "render" &&
-          state.hasJsx
-        ) {
-          isRenderMethodOrNonClassMethodReturnType = false;
-        }
+      // if (metaData?.path && metaData.path.parentPath) {
+      //   const parent = metaData.path.parentPath;
+      //   if (
+      //     parent.node.type === "ClassMethod" &&
+      //     parent.node.key.type === "Identifier" &&
+      //     parent.node.key.name !== "render" &&
+      //     state.hasJsx
+      //   ) {
+      //     isRenderMethodOrNonClassMethodReturnType = false;
+      //   }
 
-        // Ignore function declarations as well
-        if (parent.node.type === "FunctionDeclaration") {
-          isRenderMethodOrNonClassMethodReturnType = false;
-        }
-      }
+      //   // Ignore function declarations as well
+      //   if (parent.node.type === "FunctionDeclaration") {
+      //     isRenderMethodOrNonClassMethodReturnType = false;
+      //   }
+      // }
 
-      if (
-        ((matchesFullyQualifiedName("React", "Node")(id) ||
-          // We have a bunch of code where the `render()` methods' return type
-          // is set to `React.Element<"div">` or something like that.  This was
-          // the result of a codemod that inserted inferred types.  We'd like
-          // our code to be more consistent moving forward so if we find a `render()`
-          // method with a return type like this we convert it to `React.ReactNode`.
-          matchesFullyQualifiedName("React", "Element")(id)) &&
-          isRenderMethodOrNonClassMethodReturnType) ||
-        (matchesFullyQualifiedName("React", "MixedElement")(id) && !params)
-      ) {
-        const parentNode = metaData?.path?.parentPath?.node;
-        let hasNull = false;
-        if (parentNode && "body" in parentNode) {
-          const parentPath = metaData?.path?.parentPath;
-          const scope = metaData?.path?.scope;
-          hasNull = hasNullReturn(
-            parentNode.body as t.BlockStatement,
-            scope,
-            parentPath
-          );
-        }
-        const reactElement = matchesFullyQualifiedName(
-          "React",
-          "MixedElement"
-        )(id)
-          ? t.tsTypeReference(
-              t.tsQualifiedName(
-                t.identifier("React"),
-                t.identifier("ReactElement")
-              )
-            )
-          : t.tsTypeReference(
-              t.tsQualifiedName(
-                t.identifier("React"),
-                t.identifier("ReactNode")
-              )
-            );
-        if (hasNull) {
-          return t.tsUnionType([reactElement, t.tsNullKeyword()]);
-        } else {
-          return reactElement;
-        }
-      }
+      // if (
+      //   ((matchesFullyQualifiedName("React", "Node")(id) ||
+      //     // We have a bunch of code where the `render()` methods' return type
+      //     // is set to `React.Element<"div">` or something like that.  This was
+      //     // the result of a codemod that inserted inferred types.  We'd like
+      //     // our code to be more consistent moving forward so if we find a `render()`
+      //     // method with a return type like this we convert it to `React.ReactNode`.
+      //     matchesFullyQualifiedName("React", "Element")(id)) &&
+      //     isRenderMethodOrNonClassMethodReturnType) ||
+      //   (matchesFullyQualifiedName("React", "MixedElement")(id) && !params)
+      // ) {
+      //   const parentNode = metaData?.path?.parentPath?.node;
+      //   let hasNull = false;
+      //   if (parentNode && "body" in parentNode) {
+      //     const parentPath = metaData?.path?.parentPath;
+      //     const scope = metaData?.path?.scope;
+      //     hasNull = hasNullReturn(
+      //       parentNode.body as t.BlockStatement,
+      //       scope,
+      //       parentPath
+      //     );
+      //   }
+      //   const reactElement = matchesFullyQualifiedName(
+      //     "React",
+      //     "MixedElement"
+      //   )(id)
+      //     ? t.tsTypeReference(
+      //         t.tsQualifiedName(
+      //           t.identifier("React"),
+      //           t.identifier("ReactElement")
+      //         )
+      //       )
+      //     : t.tsTypeReference(
+      //         t.tsQualifiedName(
+      //           t.identifier("React"),
+      //           t.identifier("ReactElement")
+      //         )
+      //       );
+      //   if (hasNull) {
+      //     return t.tsUnionType([reactElement, t.tsNullKeyword()]);
+      //   } else {
+      //     return reactElement;
+      //   }
+      // }
 
       // `React.ChildrenArray<T>` -> `Array<T> | T`
       // TypeScript is unable to do as strict of checks on React Children as flow. As a result we need to be able to

--- a/src/convert/private-types.test.ts
+++ b/src/convert/private-types.test.ts
@@ -17,7 +17,7 @@ describe("transform type annotations", () => {
 
   it("converts React$Element", async () => {
     const src = `const Component = (props: Props): React$Element => {return <div />};`;
-    const expected = `const Component = (props: Props): React.ReactElement => {return <div />};`;
+    const expected = `const Component = (props: Props): React.Element => {return <div />};`;
     expect(await transform(src)).toBe(expected);
   });
 
@@ -29,8 +29,9 @@ describe("transform type annotations", () => {
 
   it("converts Flow namespaces", async () => {
     const src = `const Component = (props: Props): Any$Thing => {return <div />};`;
-    const expected = `const Component = (props: Props): React.ReactElement => {return <div />};`;
-    expect(await transform(src)).toBe(expected);
+    expect(await transform(src)).toMatchInlineSnapshot(
+      `"const Component = (props: Props): Any.Thing => {return <div />};"`
+    );
   });
 
   it("does not convert Flow namespace when keepPrivateTypes is set", async () => {
@@ -40,7 +41,7 @@ describe("transform type annotations", () => {
       },
     });
     const src = `const Component = (props: Props): Any$Thing => {return <div />};`;
-    const expected = `const Component = (props: Props): React.ReactElement => {return <div />};`;
+    const expected = `const Component = (props: Props): Any$Thing => {return <div />};`;
     expect(await transform(src, state)).toBe(expected);
   });
 

--- a/src/convert/type-annotations.test.ts
+++ b/src/convert/type-annotations.test.ts
@@ -415,10 +415,13 @@ describe("transform type annotations", () => {
     ) => {
       return <Test {...props} globals={globals} />;
     };`;
-    const expected = dedent`const Test = (props: Props & DefaultProps) => {
-      return <Test {...props} globals={globals} />;
-    };`;
-    expect(await transform(src)).toBe(expected);
+    expect(await transform(src)).toMatchInlineSnapshot(`
+      "const Test = (
+        props: Props & DefaultProps,
+      ) => {
+        return <Test {...props} globals={globals} />;
+      };"
+    `);
   });
 
   it("Converts React.ElementProps", async () => {
@@ -439,12 +442,6 @@ describe("transform type annotations", () => {
     expect(await transform(src)).toBe(expected);
   });
 
-  it("Converts React.MixedElement", async () => {
-    const src = `function f(): React.MixedElement {};`;
-    const expected = `function f(): React.ReactElement {};`;
-    expect(await transform(src)).toBe(expected);
-  });
-
   it("Converts React.Portal with type parameters", async () => {
     const src = `function f(): React.Portal<Props> {};`;
     const expected = `function f(): React.ReactPortal<Props> {};`;
@@ -457,16 +454,17 @@ describe("transform type annotations", () => {
     expect(await transform(src)).toBe(expected);
   });
 
-  it("Converts React.Node to React.ReactElement or null in arrow function return", async () => {
+  it.only("Converts React.Node to React.ReactElement or null in arrow function return", async () => {
     const src = dedent`const Component = (props: Props): React.Node => {
       if (foo) return (<div />);
       return null;
     };`;
-    const expected = dedent`const Component = (props: Props): React.ReactElement => {
-      if (foo) return (<div />);
-      return null;
-    };`;
-    expect(await transform(src)).toBe(expected);
+    expect(await transform(src)).toMatchInlineSnapshot(`
+      "const Component = (props: Props): React.ReactElement | null => {
+        if (foo) return (<div />);
+        return null;
+      };"
+    `);
   });
 
   it("Converts React.Node to React.ReactElement in normal function", async () => {


### PR DESCRIPTION
## Summary:
Functional components can only return React.ReactElement or React.ReactElement | null.  There were a number of edge cases we weren't handling correctly.  This PR handles those edges.  I've also simplified the code a bit by ignoring certain edge cases that don't appear in our code and centralizing the handling of React.Node within functional-components.ts.

Issue: FEI-5177

## Test plan:
- yarn test
- run the codemod on webapp/services/static