### PR TITLE
Update the codemod to handle even moar readonly types

### DIFF
--- a/src/convert/migrate/type.ts
+++ b/src/convert/migrate/type.ts
@@ -145,6 +145,26 @@ function actuallyMigrateType(
         return t.tsTypeReference(t.identifier("ReadonlyArray"), params);
       }
 
+      // `$ReadOnlySet<T>` → `ReadonlySet<T>`
+      if (
+        id.type === "Identifier" &&
+        id.name === "$ReadOnlySet" &&
+        params &&
+        params.params.length === 1
+      ) {
+        return t.tsTypeReference(t.identifier("ReadonlySet"), params);
+      }
+
+      // `$ReadOnlyMap<K, V>` → `ReadonlyMap<K, V>`
+      if (
+        id.type === "Identifier" &&
+        id.name === "$ReadOnlyMap" &&
+        params &&
+        params.params.length === 2
+      ) {
+        return t.tsTypeReference(t.identifier("ReadonlyMap"), params);
+      }
+
       // `$ReadOnly<T>` → `Readonly<T>`
       if (
         id.type === "Identifier" &&

--- a/src/convert/type-annotations.test.ts
+++ b/src/convert/type-annotations.test.ts
@@ -454,7 +454,7 @@ describe("transform type annotations", () => {
     expect(await transform(src)).toBe(expected);
   });
 
-  it.only("Converts React.Node to React.ReactElement or null in arrow function return", async () => {
+  it("Converts React.Node to React.ReactElement or null in arrow function return", async () => {
     const src = dedent`const Component = (props: Props): React.Node => {
       if (foo) return (<div />);
       return null;
@@ -478,7 +478,7 @@ describe("transform type annotations", () => {
       if (foo) return (<div />);
       return null;
     };`;
-    const expected = dedent`function Component(props: Props): React.ReactElement {
+    const expected = dedent`function Component(props: Props): React.ReactElement | null {
       if (foo) return (<div />);
       return null;
     };`;
@@ -904,6 +904,20 @@ class C {
     it("converts $Partial<T> to Partial<T>", async () => {
       const src = `type PartialFoo = $Partial<Foo>;`;
       const expected = `type PartialFoo = Partial<Foo>;`;
+      expect(await transform(src)).toBe(expected);
+    });
+  });
+
+  describe("readonly types", () => {
+    it.each`
+      input                   | output
+      ${"$ReadOnly<T>"}       | ${"Readonly<T>"}
+      ${"$ReadOnlyArray<T>"}  | ${"ReadonlyArray<T>"}
+      ${"$ReadOnlyMap<K, V>"} | ${"ReadonlyMap<K, V>"}
+      ${"$ReadOnlySet<T>"}    | ${"ReadonlySet<T>"}
+    `("converts $input to $output", async ({ input, output }) => {
+      const src = `type Foo = ${input};`;
+      const expected = `type Foo = ${output};`;
       expect(await transform(src)).toBe(expected);
     });
   });


### PR DESCRIPTION
## Summary:
There are a few more readonly types that webapp was using that the codemod can transform for us.

Issue: None

## Test plan:
- yarn test type-annotations