### PR TITLE
Update all import paths

### DIFF
--- a/src/convert/declarations.test.ts
+++ b/src/convert/declarations.test.ts
@@ -107,16 +107,18 @@ describe("transform declarations", () => {
 
     it("drops js imports when flag is present", async () => {
       const src = [
-        `import {foo} from './foo.js';`,
-        `export {bar} from './bar.js';`,
-        `export * from './baz.js';`,
-        `const {qux} = require('./qux.js');`,
+        `import {a} from './a.js';`,
+        `export {b} from './b.js';`,
+        `export * from './c.js';`,
+        `const {d} = require('./d.js');`,
+        `const {e} = import('./e.js');`,
       ].join("\n");
       const expected = [
-        `import {foo} from './foo';`,
-        `export {bar} from './bar';`,
-        `export * from './baz';`,
-        `const {qux} = require('./qux');`,
+        `import {a} from './a';`,
+        `export {b} from './b';`,
+        `export * from './c';`,
+        `const {d} = require('./d');`,
+        `const {e} = import('./e');`,
       ].join("\n");
       expect(
         await transform(

--- a/src/convert/declarations.test.ts
+++ b/src/convert/declarations.test.ts
@@ -106,8 +106,18 @@ describe("transform declarations", () => {
     });
 
     it("drops js imports when flag is present", async () => {
-      const src = `import {foo} from './foo.js';`;
-      const expected = `import {foo} from './foo';`;
+      const src = [
+        `import {foo} from './foo.js';`,
+        `export {bar} from './bar.js';`,
+        `export * from './baz.js';`,
+        `const {qux} = require('./qux.js');`,
+      ].join("\n");
+      const expected = [
+        `import {foo} from './foo';`,
+        `export {bar} from './bar';`,
+        `export * from './baz';`,
+        `const {qux} = require('./qux');`,
+      ].join("\n");
       expect(
         await transform(
           src,

--- a/src/convert/declarations.ts
+++ b/src/convert/declarations.ts
@@ -162,7 +162,10 @@ export function transformDeclarations({
 
     CallExpression(path) {
       const { node } = path;
-      if (node.callee.type === "Identifier" && node.callee.name === "require") {
+      if (
+        (node.callee.type === "Identifier" && node.callee.name === "require") ||
+        node.callee.type === "Import"
+      ) {
         if (
           node.arguments.length === 1 &&
           node.arguments[0].type === "StringLiteral"


### PR DESCRIPTION
## Summary:
The codemod was only updating import paths from 'import' statements.  This PR updates the codemod to handle:
- [x] import
- [x] export * from
- [x] export {foo} from
- [x] require()
- [x] import()

Issue: None

## Test plan:
- yarn test declarations