### PR TITLE
Upgrade recast

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "jest-junit": "^12.0.0",
     "patch-package": "^6.4.7",
     "prettier": "^2.4.1",
-    "recast": "^0.20.4",
+    "recast": "^0.21.5",
     "signale": "^1.4.0",
     "ts-jest": "^26.0.0",
     "ts-morph": "^13.0.2",

--- a/patches/recast+0.21.5.patch
+++ b/patches/recast+0.21.5.patch
@@ -2,13 +2,13 @@ diff --git a/node_modules/recast/lib/printer.js b/node_modules/recast/lib/printe
 index 8cbc392..470b3c4 100644
 --- a/node_modules/recast/lib/printer.js
 +++ b/node_modules/recast/lib/printer.js
-@@ -1730,8 +1730,12 @@ function genericPrintNoParens(path, options, print) {
+@@ -1755,8 +1755,12 @@ function genericPrintNoParens(path, options, print) {
          }
          case "TSTypeParameterDeclaration":
          case "TSTypeParameterInstantiation":
-+          // If the first parameter has a comment, we want to insert a new line to avoid causing a syntax error:
-+          const parameterNode = path.getValue()
-+          const [firstParam] = parameterNode.params || [];
++            // If the first parameter has a comment, we want to insert a new line to avoid causing a syntax error:
++            const parameterNode = path.getValue();
++            const [firstParam] = parameterNode.params || [];
              return lines_1.concat([
                  "<",
 +                firstParam && firstParam.comments  && firstParam.comments.length ? lines_1.fromString("\n") : lines_1.fromString(""),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,10 +1151,10 @@ assign-symbols@^1.0.0:
   resolved "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==
 
-ast-types@0.14.2:
-  version "0.14.2"
-  resolved "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz#600b882df8583e3cd4f2df5fa20fa83759d4bdfd"
-  integrity sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==
+ast-types@0.15.2:
+  version "0.15.2"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.15.2.tgz#39ae4809393c4b16df751ee563411423e85fb49d"
+  integrity sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==
   dependencies:
     tslib "^2.0.1"
 
@@ -4181,12 +4181,12 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-recast@^0.20.4:
-  version "0.20.4"
-  resolved "https://registry.npmjs.org/recast/-/recast-0.20.4.tgz#db55983eac70c46b3fff96c8e467d65ffb4a7abc"
-  integrity sha512-6qLIBGGRcwjrTZGIiBpJVC/NeuXpogXNyRQpqU1zWPUigCphvApoCs9KIwDYh1eDuJ6dAFlQoi/QUyE5KQ6RBQ==
+recast@^0.21.5:
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.21.5.tgz#e8cd22bb51bcd6130e54f87955d33a2b2e57b495"
+  integrity sha512-hjMmLaUXAm1hIuTqOdeYObMslq/q+Xff6QE3Y2P+uoHAg2nmVlLBps2hzh1UJDdMtDTMXOFewK6ky51JQIeECg==
   dependencies:
-    ast-types "0.14.2"
+    ast-types "0.15.2"
     esprima "~4.0.0"
     source-map "~0.6.1"
     tslib "^2.0.1"


### PR DESCRIPTION
## Summary:
There were a couple of files that the codemod fails on.  Upgrading recast fixed the issue.  This PR also updates the patch file so that retain that change after the upgrade.

Issue: None

## Test plan:
- yarn typescriptify convert --path ../webapp/services/static/javascript/tutorial-scratchpad-package --dropImportExtensions --write --delete --disableFlow --skipNoFlow
- see that the codemod no longer errors on javascript/tutorial-scratchpad-package/scratchpad-page.jsx with Error: did not recognize object of type "IndexedAccessType"