### PR TITLE
Fix test file overrides

### DIFF
--- a/src/runner/process-batch.ts
+++ b/src/runner/process-batch.ts
@@ -62,15 +62,31 @@ export async function processBatchAsync(
 
         // Checks if a .ts override file exists and stops early
         // if there is one.
-        if (fs.existsSync(filePath.replace(/\.jsx?$/, ".ts"))) {
-          reporter.foundDeclarationFile(filePath);
+        if (
+          fs.existsSync(
+            filePath
+              .replace("_test.", ".test.")
+              .replace("_testdata.", ".testdata.")
+              .replace("_flowtest.", ".typestest.")
+              .replace(/\.jsx?$/, ".ts")
+          )
+        ) {
+          reporter.foundOverrideFile(filePath);
           return;
         }
 
         // Checks if a .tsx override file exists and stops early
         // if there is one.
-        if (fs.existsSync(filePath.replace(/\.jsx?$/, ".tsx"))) {
-          reporter.foundDeclarationFile(filePath);
+        if (
+          fs.existsSync(
+            filePath
+              .replace("_test.", ".test.")
+              .replace("_testdata.", ".testdata.")
+              .replace("_flowtest.", ".typestest.")
+              .replace(/\.jsx?$/, ".tsx")
+          )
+        ) {
+          reporter.foundOverrideFile(filePath);
           return;
         }
 


### PR DESCRIPTION
## Summary:
I noticed that test files with overrides were being overwritten by the codemod instead of being ignored.  I forgot to account for _test. to .test. renaming.  This PR fixes that.

Issue: None

## Test plan:
- yarn typescriptify convert --path ../webapp/services/static/javascript/testing/internal --dropImportExtensions --write --delete --disableFlow --skipNoFlow
- see that javascript/testing/internal/verify-route_test.js is skipped