### PR TITLE
tweak logic in import-jest-globals.ts to recognized gloabls being imported from webapp wrapper

### DIFF
--- a/src/convert/import-jest-globals.test.ts
+++ b/src/convert/import-jest-globals.test.ts
@@ -38,7 +38,8 @@ describe("jest globals", () => {
   });
 
   it("should not re-import globals in _test.js files that have already been imported", async () => {
-    const src = `import {describe, expect} from "@jest/globals";
+    const src = `import {expect} from "@jest/globals";
+    import {describe} from "~/testing/jest-globals";
     describe("foo", () => { expect(true).toBe(true); });`;
 
     expect(
@@ -47,7 +48,8 @@ describe("jest globals", () => {
         stateBuilder({ config: { filePath: "foo_test.js" } })
       )
     ).toMatchInlineSnapshot(`
-      "import {describe, expect} from \\"@jest/globals\\";
+      "import {expect} from \\"@jest/globals\\";
+          import {describe} from \\"~/testing/jest-globals\\";
           describe(\\"foo\\", () => { expect(true).toBe(true); });"
     `);
   });

--- a/src/convert/import-jest-globals.ts
+++ b/src/convert/import-jest-globals.ts
@@ -28,7 +28,8 @@ export function importJestGlobals({ file }: TransformerInput) {
         const parent = path.parentPath.node;
         if (
           parent.type === "ImportDeclaration" &&
-          parent.source.value === "@jest/globals" &&
+          (parent.source.value === "@jest/globals" ||
+            parent.source.value.endsWith("/jest-globals")) &&
           node.imported.type === "Identifier" &&
           GLOBALS.includes(node.imported.name)
         ) {


### PR DESCRIPTION
## Summary:
https://github.com/Khan/webapp/pull/14993 updated all route tests to import jest globals from '~/testing/jest-globals'.  After running the codemod we ended up with duplicate imports of the globals from two different places.  This PR updates the codemod to recognize those existing imports and not add new ones.

Issue: None

## Test plan:
- yarn test import-jest-globals