### PR TITLE
FEI-5215: Update codemod to update shebang

### DIFF
--- a/src/convert/default-transformer-chain.ts
+++ b/src/convert/default-transformer-chain.ts
@@ -11,6 +11,7 @@ import {
   removeFlowCommentTransformRunner,
   functionalComponentTransformerRunner,
   filterBooleanTranforRunner,
+  shebangTransformRunner,
 } from "./transform-runners";
 import { Transformer } from "./transformer";
 
@@ -29,6 +30,7 @@ export const defaultTransformerChain: readonly Transformer[] = [
   removeFlowCommentTransformRunner,
   functionalComponentTransformerRunner,
   filterBooleanTranforRunner,
+  shebangTransformRunner,
 
   // This transform must go last since it looks at `state` which can
   // be modified by any other transformer.

--- a/src/convert/shebang.test.ts
+++ b/src/convert/shebang.test.ts
@@ -2,13 +2,24 @@ import { transform } from "./utils/testing";
 
 describe("jest globals", () => {
   it("should update 'node -r @babel/register' shebang to use '@swc-node/register'", async () => {
-    const src = `#!/usr/bin/env -S node -r @swc-node/register
-    console.log("hello, world!");`;
+    const src = `#!/usr/bin/env -S node -r @babel/register
+console.log("hello, world!");`;
 
     expect(await transform(src)).toMatchInlineSnapshot(`
       "#!/usr/bin/env -S node -r @swc-node/register
-          console.log(\\"hello, world!\\");"
+
+      console.log(\\"hello, world!\\");"
     `);
+  });
+
+  it("should work with a comment on the next line", async () => {
+    const src = `#!/usr/bin/env -S node -r @babel/register
+/* eslint-disable no-console */
+// @flow
+import yargs from "yargs";
+import {entries, keys} from "@khanacademy/wonder-stuff-core";`;
+
+    expect(await transform(src)).toMatchInlineSnapshot();
   });
 
   it("should not update other shebangs", async () => {

--- a/src/convert/shebang.test.ts
+++ b/src/convert/shebang.test.ts
@@ -1,0 +1,23 @@
+import { transform } from "./utils/testing";
+
+describe("jest globals", () => {
+  it("should update 'node -r @babel/register' shebang to use '@swc-node/register'", async () => {
+    const src = `#!/usr/bin/env -S node -r @swc-node/register
+    console.log("hello, world!");`;
+
+    expect(await transform(src)).toMatchInlineSnapshot(`
+      "#!/usr/bin/env -S node -r @swc-node/register
+          console.log(\\"hello, world!\\");"
+    `);
+  });
+
+  it("should not update other shebangs", async () => {
+    const src = `#!/usr/bin/env node
+    console.log("hello, world!");`;
+
+    expect(await transform(src)).toMatchInlineSnapshot(`
+      "#!/usr/bin/env node
+          console.log(\\"hello, world!\\");"
+    `);
+  });
+});

--- a/src/convert/shebang.test.ts
+++ b/src/convert/shebang.test.ts
@@ -19,7 +19,13 @@ console.log("hello, world!");`;
 import yargs from "yargs";
 import {entries, keys} from "@khanacademy/wonder-stuff-core";`;
 
-    expect(await transform(src)).toMatchInlineSnapshot();
+    expect(await transform(src)).toMatchInlineSnapshot(`
+      "#!/usr/bin/env -S node -r @swc-node/register
+
+      /* eslint-disable no-console */
+      import yargs from \\"yargs\\";
+      import {entries, keys} from \\"@khanacademy/wonder-stuff-core\\";"
+    `);
   });
 
   it("should not update other shebangs", async () => {

--- a/src/convert/shebang.ts
+++ b/src/convert/shebang.ts
@@ -8,11 +8,12 @@ export function shebang({ file }: TransformerInput) {
   traverse(
     file,
     {
-      InterpreterDirective(path) {
-        const { node } = path;
-
-        if (node.value === "#!/usr/bin/env -S node -r @babel/register") {
-          node.value = "#!/usr/bin/env -S node -r @swc-node/register";
+      Program(path) {
+        const { interpreter } = path.node;
+        if (interpreter) {
+          if (interpreter.value === "/usr/bin/env -S node -r @babel/register") {
+            interpreter.value = "/usr/bin/env -S node -r @swc-node/register";
+          }
         }
       },
     },

--- a/src/convert/shebang.ts
+++ b/src/convert/shebang.ts
@@ -1,0 +1,21 @@
+import traverse from "@babel/traverse";
+import { TransformerInput } from "./transformer";
+
+/**
+ * Rewrite `node -r @babel/register` shebangs to use `@swc-node/register`.
+ */
+export function shebang({ file }: TransformerInput) {
+  traverse(
+    file,
+    {
+      InterpreterDirective(path) {
+        const { node } = path;
+
+        if (node.value === "#!/usr/bin/env -S node -r @babel/register") {
+          node.value = "#!/usr/bin/env -S node -r @swc-node/register";
+        }
+      },
+    },
+    undefined
+  );
+}

--- a/src/convert/transform-runners.ts
+++ b/src/convert/transform-runners.ts
@@ -14,6 +14,7 @@ import { annotateNoFlow } from "./annotate-no-flow";
 import { transformFunctionalComponents } from "./functional-components";
 import { transformFilterBoolean } from "./migrate/filter-boolean";
 import { importJestGlobals } from "./import-jest-globals";
+import { shebang } from "./shebang";
 
 const standardTransformRunnerFactory = (transformer: Transformer) => {
   return (transformerInput: TransformerInput) => {
@@ -74,3 +75,6 @@ export const filterBooleanTranforRunner: Transformer =
 
 export const importJestGlobalsTransformRunner: Transformer =
   standardTransformRunnerFactory(importJestGlobals);
+
+export const shebangTransformRunner: Transformer =
+  standardTransformRunnerFactory(shebang);

--- a/src/runner/process-batch.ts
+++ b/src/runner/process-batch.ts
@@ -218,6 +218,8 @@ export async function processBatchAsync(
           }
         }
 
+        // `{ mode: stats.mode }` is used to copy the file permissions from the original file.
+        // This is important for node scripts which often have the executable bit set.
         await fs.outputFile(tsFilePath, newFileText, { mode: stats.mode });
       } catch (error) {
         // Report errors, but don’t crash the worker...

--- a/src/runner/process-batch.ts
+++ b/src/runner/process-batch.ts
@@ -60,6 +60,8 @@ export async function processBatchAsync(
           return;
         }
 
+        const stats = fs.statSync(filePath);
+
         // Checks if a .ts override file exists and stops early
         // if there is one.
         if (
@@ -216,7 +218,7 @@ export async function processBatchAsync(
           }
         }
 
-        await fs.outputFile(tsFilePath, newFileText);
+        await fs.outputFile(tsFilePath, newFileText, { mode: stats.mode });
       } catch (error) {
         // Report errors, but don’t crash the worker...
         reporter.error(filePath, error);


### PR DESCRIPTION
## Summary:
After migrating to TypeScript we can't use 'node -r @babel/register' because it doesn't process .ts(x) files by default for some reason and passing '--extensions ".ts,.tsx"' doesn't seem to work.  Instead, we're going to switch to 'node -r @swc-node/register' which does work.  Also, 'swc' is faster than 'babel' which should reduce startup time for scripts.

Issue: FEI-5215

TODO:
- [x] figure out how to maintain file permissions when writing files out

## Test plan:
- `yarn test shebang`
- `yarn typescriptify fix --autoSuppressErrors --removeUnused -p ../webapp/services/static/deploy --config ../webapp/services/static/tsconfig.json`
- see that the deploy/deploy.ts and deploy/reaper.ts were updated appropriately and that they are executable