### PR TITLE
FEI-5217.2: Update eslint disable comments when converting a file

### DIFF
--- a/src/runner/fix-eslint-issues.test.ts
+++ b/src/runner/fix-eslint-issues.test.ts
@@ -7,8 +7,8 @@ describe("fixEslintIssues", () => {
 
   it("should replace no-unused-var with @typescript-eslint/no-unused-vars", () => {
     const input = `// @flow
-const a = 5; // eslint-disable-line no-unused-var
-// eslint-disable-next-line no-unused-var
+const a = 5; // eslint-disable-line no-unused-vars
+// eslint-disable-next-line no-unused-vars
 const b = 10;`;
 
     const output = fixEslintIssues(input, "test.js", "test.ts");

--- a/src/runner/fix-eslint-issues.test.ts
+++ b/src/runner/fix-eslint-issues.test.ts
@@ -1,0 +1,36 @@
+import { fixEslintIssues } from "./fix-eslint-issues";
+
+describe("fixEslintIssues", () => {
+  it("should do something", () => {
+    expect(true).toBe(true);
+  });
+
+  it("should replace no-unused-var with @typescript-eslint/no-unused-vars", () => {
+    const input = `// @flow
+const a = 5; // eslint-disable-line no-unused-var
+// eslint-disable-next-line no-unused-var
+const b = 10;`;
+
+    const output = fixEslintIssues(input, "test.js", "test.ts");
+
+    expect(output).toMatchInlineSnapshot(`
+      "// @flow
+      const a = 5; // eslint-disable-line @typescript-eslint/no-unused-vars
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const b = 10;"
+    `);
+  });
+
+  it("should add eslint-disable static-service/require-stories if converting from .js to .tsx", () => {
+    const input = `// @flow
+console.log("hello, world!");`;
+
+    const output = fixEslintIssues(input, "test.js", "test.tsx");
+
+    expect(output).toMatchInlineSnapshot(`
+      "/* eslint-disable static-service/require-stories */
+      // @flow
+      console.log(\\"hello, world!\\");"
+    `);
+  });
+});

--- a/src/runner/fix-eslint-issues.ts
+++ b/src/runner/fix-eslint-issues.ts
@@ -1,0 +1,19 @@
+export function fixEslintIssues(
+  code: string,
+  filePath: string,
+  targetFilePath: string
+) {
+  let result = code.replace(
+    /no-unused-var/g,
+    "@typescript-eslint/no-unused-vars"
+  );
+
+  // If the file was a .js file then it probably didn't have any stories.
+  // If the new file is a .tsx then we'll be checking if it does have stories
+  // so we need to disable `static-service/require-stories` for this file.
+  if (filePath.endsWith(".js") && targetFilePath.endsWith(".tsx")) {
+    result = "/* eslint-disable static-service/require-stories */\n" + result;
+  }
+
+  return result;
+}

--- a/src/runner/fix-eslint-issues.ts
+++ b/src/runner/fix-eslint-issues.ts
@@ -4,7 +4,7 @@ export function fixEslintIssues(
   targetFilePath: string
 ) {
   let result = code.replace(
-    /no-unused-var/g,
+    /no-unused-vars/g,
     "@typescript-eslint/no-unused-vars"
   );
 

--- a/src/runner/process-batch.ts
+++ b/src/runner/process-batch.ts
@@ -18,6 +18,7 @@ import { ConfigurableTypeProvider } from "../convert/utils/configurable-type-pro
 import { hasDeclaration } from "../convert/utils/common";
 import { FlowFileList, FlowFileType } from "./find-flow-files";
 import { logger } from "./logger";
+import { fixEslintIssues } from "./fix-eslint-issues";
 
 export const FlowCommentRegex = /((\/){2,} ?)*@flow.*\n+/;
 
@@ -220,7 +221,13 @@ export async function processBatchAsync(
 
         // `{ mode: stats.mode }` is used to copy the file permissions from the original file.
         // This is important for node scripts which often have the executable bit set.
-        await fs.outputFile(tsFilePath, newFileText, { mode: stats.mode });
+        await fs.outputFile(
+          tsFilePath,
+          fixEslintIssues(newFileText, filePath, targetFilePath),
+          {
+            mode: stats.mode,
+          }
+        );
       } catch (error) {
         // Report errors, but don’t crash the worker...
         reporter.error(filePath, error);


### PR DESCRIPTION
## Summary:
Lots of files that contain JSX in webapp use the .js file extension and thus are ignored by our static-service/require-stories eslint rule.  This means that the majority of those files don't have stories.  When these files are converted to TypeScript their file extension will change to .tsx and we will be check if they have stories.  This PR adds logic to automatically add an eslint-disable comment for this rule at the top of such files.

It also renames 'no-unused-var' in comments to '@typescript-eslint/no-unused-vars' to handle the fact that we're switch from one rule to the other.  This is important because we have another rule in webapp that complains about the use of eslint-disable comments that aren't needed.

Issue: FEI-5217

## Test plan:
- yarn test fix-eslint-issues